### PR TITLE
docs: add openHAB Integration Guide (Phase 2)

### DIFF
--- a/content/_index.de.md
+++ b/content/_index.de.md
@@ -56,7 +56,7 @@ Die Module dieses Projekts unterstützen Sie dabei, Ihren Swimmingpool in ein Sm
   {{< hextra/feature-card
     title="openHAB Integration"
     subtitle="Reibungslose Integration mit dem openHAB-Smarthome-Server. Steuerung des Pools per App auf Android und iOS."
-    link="/docs/openhab-configuration/"
+    link="/docs/openhab-integration/"
     class="aspect-auto md:aspect-[1.1/1] max-md:min-h-[280px]"
     image="/img/openhab-sitemap-pool-automation.jpg"
     imageClass="top-[40%] left-[36px] w-[180%] sm:w-[110%] dark:opacity-80"

--- a/content/_index.md
+++ b/content/_index.md
@@ -56,7 +56,7 @@ The modules of this project support you to transform your swimming pool into a s
   {{< hextra/feature-card
     title="openHAB Integration"
     subtitle="Smooth integration with openHAB smart home server. Control your pool via mobile app on Android and iOS."
-    link="/docs/openhab-configuration/"
+    link="/docs/openhab-integration/"
     class="aspect-auto md:aspect-[1.1/1] max-md:min-h-[280px]"
     image="/img/openhab-sitemap-pool-automation.jpg"
     imageClass="top-[40%] left-[36px] w-[180%] sm:w-[110%] dark:opacity-80"

--- a/content/docs/_index.de.md
+++ b/content/docs/_index.de.md
@@ -11,8 +11,10 @@ Dieses Projekt ist in verschiedene Module aufgeteilt:
 
 - **[Pool Controller](/docs/pool-controller/)**:
   Das Herz der Steuerung — zentrale Steuerlogik auf ESP32-Basis.
+- **[openHAB Integration](/docs/openhab-integration/)**:
+  Schritt-für-Schritt-Anleitung zur Integration des Pool Controllers mit openHAB.
 - **[openHAB Konfiguration](/docs/openhab-configuration/)**:
-  Sitemap und Regeln zur Steuerung des Pools via openHAB Smartphone-App.
+  Referenz-Sitemap, Items und Regeln für openHAB.
 - **[Grafana Dashboard](/docs/grafana-dashboard/)**:
   Visualisieren Sie Ihre Pool-Daten mit einem ansprechenden Dashboard.
 - **[Pool Monitor](/docs/pool-monitor/)**:

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -11,8 +11,10 @@ This project is split into several modules:
 
 - **[Pool Controller](/docs/pool-controller/)**:
   The heart of the 🏊 Smart Swimming Pool — ESP32-based central control logic.
+- **[openHAB Integration](/docs/openhab-integration/)**:
+  Step-by-step guide to integrate the Pool Controller with openHAB.
 - **[openHAB Configuration](/docs/openhab-configuration/)**:
-  Sitemap and rules to control 🏊 Smart Swimming Pool via the openHAB mobile app.
+  Reference sitemap, items and rules for openHAB.
 - **[Grafana Dashboard](/docs/grafana-dashboard/)**:
   Visualize your pool data with a beautiful dashboard.
 - **[Pool Monitor](/docs/pool-monitor/)**:

--- a/content/docs/getting-started/_index.de.md
+++ b/content/docs/getting-started/_index.de.md
@@ -188,7 +188,8 @@ Sobald Ihr Pool Controller läuft:
 - Richten Sie das **[Grafana Dashboard](/docs/grafana-dashboard/)** für Temperaturverläufe ein
 - Fügen Sie den **[Pool Monitor](/docs/pool-monitor/)** für ein eigenes Display hinzu
 - Besuchen Sie das **[FAQ](/docs/troubleshooting/)** bei Problemen
-- Erkunden Sie die **[openHAB Konfiguration](/docs/openhab-configuration/)**, falls Sie openHAB nutzen
+- Folgen Sie der **[openHAB Integrations-Anleitung](/docs/openhab-integration/)**, um openHAB Schritt für Schritt einzurichten
+- Nutzen Sie die **[openHAB Konfiguration](/docs/openhab-configuration/)** als Referenz für die vollständigen Konfigurationsdateien
 
 ## Vorbereitungen
 

--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -188,7 +188,8 @@ Once your Pool Controller is running:
 - Set up the **[Grafana Dashboard](/docs/grafana-dashboard/)** to visualize temperature trends
 - Add the **[Pool Monitor](/docs/pool-monitor/)** for a dedicated display
 - Check the **[FAQ](/docs/troubleshooting/)** if you run into issues
-- Explore the **[openHAB Configuration](/docs/openhab-configuration/)** if you use openHAB
+- Follow the **[openHAB Integration Guide](/docs/openhab-integration/)** to set up openHAB step by step
+- Reference the **[openHAB Configuration](/docs/openhab-configuration/)** for the complete openHAB config files
 
 ## Preparations
 

--- a/content/docs/openhab-integration/_index.de.md
+++ b/content/docs/openhab-integration/_index.de.md
@@ -1,0 +1,347 @@
+---
+title: openHAB Integration
+weight: 15
+tags: ["docs", "openHAB", "tutorial"]
+---
+
+**🏊 Smart Swimming Pool: Den Pool Controller mit openHAB integrieren**
+
+Im Gegensatz zu [Home Assistant](/docs/getting-started/#step-4-home-assistant-integration), das den Pool Controller automatisch per MQTT Discovery erkennt, erfordert openHAB eine **manuelle Konfiguration**. Diese Anleitung führt Sie Schritt für Schritt durch den Prozess.
+
+> 💡 **Sie nutzen bereits openHAB?**  
+> Die [openHAB Konfiguration](/docs/openhab-configuration/) enthält die vollständigen Referenzdateien (Things, Items, Sitemap). Diese Anleitung erklärt, *wie* Sie diese einrichten und an Ihr System anpassen.
+
+---
+
+## Voraussetzungen
+
+Bevor Sie beginnen, stellen Sie sicher, dass Folgendes vorhanden ist:
+
+1. **Der Pool Controller** ist geflasht und läuft in Ihrem Netzwerk (siehe [Erste Schritte](/docs/getting-started/))
+2. **Ein MQTT-Broker** (z. B. [Mosquitto](https://mosquitto.org/)) — installieren Sie ihn auf dem gleichen Rechner wie openHAB oder in Ihrem Netzwerk
+3. **openHAB** (Version 3 oder 4) läuft und ist über die Weboberfläche erreichbar
+
+---
+
+## Schritt 1: MQTT Binding installieren
+
+In der openHAB-Weboberfläche:
+
+1. Gehen Sie zu **Einstellungen → Add-ons → Bindings**
+2. Suchen Sie nach **"MQTT"**
+3. Installieren Sie das **MQTT Binding** (offizielles Binding des openHAB-Projekts)
+4. Kein Neustart erforderlich — das Binding ist sofort aktiv
+
+---
+
+## Schritt 2: MQTT Broker Thing konfigurieren
+
+1. Gehen Sie zu **Einstellungen → Things**
+2. Klicken Sie auf **+** (Thing hinzufügen)
+3. Suchen Sie nach **"MQTT"** und wählen Sie **MQTT Broker**
+4. Konfigurieren Sie:
+   - **Host**: IP-Adresse Ihres MQTT-Brokers (z. B. `192.168.1.100` oder `core-mosquitto`)
+   - **Port**: `1883` (Standard, unverschlüsselt)
+   - **Client ID**: `openHAB-pool` (muss auf Ihrem Broker eindeutig sein)
+   - **Benutzername/Passwort**: Nur wenn Ihr Broker eine Authentifizierung erfordert
+5. Klicken Sie auf **Thing erstellen**
+
+Das Broker Thing sollte innerhalb von Sekunden **Online** sein. Falls nicht, überprüfen Sie, ob Ihr MQTT-Broker läuft und erreichbar ist.
+
+---
+
+## Schritt 3: MQTT-Topics ermitteln
+
+Der Pool Controller v3.x veröffentlicht seine Daten im [Home Assistant MQTT Discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery)-Format. Sie müssen die **genauen Topics** Ihres Controllers ermitteln, um openHAB korrekt zu konfigurieren.
+
+### Option A: MQTT Explorer (Empfohlen)
+
+Installieren Sie [MQTT Explorer](http://mqtt-explorer.com/) auf Ihrem Computer:
+
+1. Verbinden Sie sich mit Ihrem MQTT-Broker (Host, Port — wie oben)
+2. Navigieren Sie zum Präfix `homeassistant/`
+3. Sie sehen die Topics nach Entitätstyp organisiert:
+   ```
+   homeassistant/
+   ├── sensor/
+   │   └── pool-controller/
+   │       ├── pool_temp/
+   │       ├── solar_temp/
+   │       └── availability/
+   ├── switch/
+   │   └── pool-controller/
+   │       ├── pool_pump/
+   │       └── solar_pump/
+   ├── select/
+   │   └── pool-controller/
+   │       └── operation_mode/
+   └── number/
+       └── pool-controller/
+           ├── pool_max_temp/
+           ├── solar_min_temp/
+           ├── hysteresis/
+           ├── timer_start_h/
+           ├── timer_start_m/
+           ├── timer_end_h/
+           └── timer_end_m/
+   ```
+
+Jede Entität hat:
+- `config` — Discovery-Payload mit Metadaten
+- `state` — aktueller Wert
+- `set` — Befehlstopic (für beschreibbare Entitäten)
+
+### Option B: Kommandozeile (mosquitto_sub)
+
+Wenn Sie die Kommandozeile bevorzugen:
+
+```bash
+# Alle Pool-Controller-Topics abonnieren
+mosquitto_sub -h <broker-ip> -t "homeassistant/#" -v
+
+# Oder nur nach dem Pool Controller filtern
+mosquitto_sub -h <broker-ip> -t "homeassistant/+/pool-controller/#" -v
+```
+
+> ⚠️ **Hinweis**: Die Geräte-ID Ihres Controllers kann von `pool-controller` abweichen, wenn Sie die **MQTT-Geräte-ID** in der Weboberfläche des Pool Controllers geändert haben. Passen Sie das Topic-Präfix entsprechend an.
+
+---
+
+## Schritt 4: Thing-Datei erstellen
+
+openHAB 3+ verwendet **`.things`-Dateien** in `$OPENHAB_CONF/things/`, um MQTT-Topic-Things zu definieren.
+
+Erstellen Sie `$OPENHAB_CONF/things/pool-controller.things`:
+
+```java
+Bridge mqtt:broker:mosquitto "Mosquitto" [ host="127.0.0.1", port=1883, secure=false, clientID="openHAB-pool" ]
+{
+    Thing topic pool-controller "Pool Controller" @ "Außenbereich" {
+        Channels:
+            // Betriebsmodus
+            Type string : operationMode "Betriebsmodus"
+                [ stateTopic="homeassistant/select/pool-controller/operation_mode/state",
+                  commandTopic="homeassistant/select/pool-controller/operation_mode/set" ]
+
+            // Konfigurationszahlen
+            Type number : maxPoolTemp "Max. Pooltemperatur"
+                [ stateTopic="homeassistant/number/pool-controller/pool_max_temp/state",
+                  commandTopic="homeassistant/number/pool-controller/pool_max_temp/set" ]
+            Type number : minSolarTemp "Min. Solartemperatur"
+                [ stateTopic="homeassistant/number/pool-controller/solar_min_temp/state",
+                  commandTopic="homeassistant/number/pool-controller/solar_min_temp/set" ]
+            Type number : hysteresis "Hysterese"
+                [ stateTopic="homeassistant/number/pool-controller/hysteresis/state",
+                  commandTopic="homeassistant/number/pool-controller/hysteresis/set" ]
+            Type number : timerStartH "Timer Start Stunde"
+                [ stateTopic="homeassistant/number/pool-controller/timer_start_h/state",
+                  commandTopic="homeassistant/number/pool-controller/timer_start_h/set" ]
+            Type number : timerStartM "Timer Start Minute"
+                [ stateTopic="homeassistant/number/pool-controller/timer_start_m/state",
+                  commandTopic="homeassistant/number/pool-controller/timer_start_m/set" ]
+            Type number : timerEndH "Timer Ende Stunde"
+                [ stateTopic="homeassistant/number/pool-controller/timer_end_h/state",
+                  commandTopic="homeassistant/number/pool-controller/timer_end_h/set" ]
+            Type number : timerEndM "Timer Ende Minute"
+                [ stateTopic="homeassistant/number/pool-controller/timer_end_m/state",
+                  commandTopic="homeassistant/number/pool-controller/timer_end_m/set" ]
+
+            // Pumpen
+            Type switch : poolPump "Poolpumpe"
+                [ stateTopic="homeassistant/switch/pool-controller/pool_pump/state",
+                  commandTopic="homeassistant/switch/pool-controller/pool_pump/set" ]
+            Type switch : solarPump "Solarpumpe"
+                [ stateTopic="homeassistant/switch/pool-controller/solar_pump/state",
+                  commandTopic="homeassistant/switch/pool-controller/solar_pump/set" ]
+
+            // Temperaturen
+            Type number : poolTemp "Pooltemperatur"
+                [ stateTopic="homeassistant/sensor/pool-controller/pool_temp/state" ]
+            Type number : solarTemp "Solartemperatur"
+                [ stateTopic="homeassistant/sensor/pool-controller/solar_temp/state" ]
+
+            // Systeminfo
+            Type number : signal "WiFi-Signal"
+                [ stateTopic="homeassistant/sensor/pool-controller/signal/state" ]
+            Type number : uptime "Betriebszeit"
+                [ stateTopic="homeassistant/sensor/pool-controller/uptime/state" ]
+            Type string : fwVersion "Firmware-Version"
+                [ stateTopic="homeassistant/sensor/pool-controller/fw_version/state" ]
+    }
+}
+```
+
+> **Ersetzen Sie `pool-controller`** in den Topic-Pfaden durch Ihre tatsächliche Geräte-ID, falls Sie diese geändert haben.
+
+---
+
+## Schritt 5: Items-Datei erstellen
+
+Items verknüpfen die MQTT-Kanäle mit openHAB-Items, die in Benutzeroberflächen angezeigt und in Regeln verwendet werden können.
+
+Erstellen Sie `$OPENHAB_CONF/items/pool-controller.items`:
+
+```java
+// Gruppen
+Group gPool_Controller "Pool Controller" <swimmingpool>
+
+// Betriebsmodus
+String Pool_OpMode "Betriebsmodus [%s]" <settings> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:operationMode", autoupdate="true" }
+
+// Konfiguration
+Number Pool_MaxTemp "Max. Pooltemp. [%.1f °C]" <heating> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:maxPoolTemp", autoupdate="true" }
+Number Pool_MinSolarTemp "Min. Solartemp. [%.1f °C]" <heating> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:minSolarTemp", autoupdate="true" }
+Number Pool_Hysteresis "Hysterese [%.1f K]" <line> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:hysteresis", autoupdate="true" }
+
+Number Pool_Timer_Start_H "Timer Start Std. [%.0f h]" <time> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:timerStartH", autoupdate="true" }
+Number Pool_Timer_Start_M "Timer Start Min. [%.0f m]" <time> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:timerStartM", autoupdate="true" }
+Number Pool_Timer_End_H "Timer Ende Std. [%.0f h]" <time> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:timerEndH", autoupdate="true" }
+Number Pool_Timer_End_M "Timer Ende Min. [%.0f m]" <time> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:timerEndM", autoupdate="true" }
+
+// Pumpen
+Switch Pool_PoolPump "Poolpumpe" <pump> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:poolPump", autoupdate="false" }
+Switch Pool_SolarPump "Solarpumpe" <solarplant> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:solarPump", autoupdate="false" }
+
+// Temperaturen
+Number Pool_PoolTemp "Pooltemperatur [%.1f °C]" <temperature> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:poolTemp", autoupdate="false" }
+Number Pool_SolarTemp "Solartemperatur [%.1f °C]" <temperature> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:solarTemp", autoupdate="false" }
+
+// System
+Number Pool_Signal "WiFi-Signal [%.0f%%]" <network> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:signal", autoupdate="false" }
+Number Pool_Uptime "Betriebszeit [%d s]" <time> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:uptime", autoupdate="false" }
+String Pool_FWVersion "Firmware [%s]" <text> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:fwVersion", autoupdate="false" }
+```
+
+### Channel-UID-Format
+
+Die Channel-UID folgt diesem Muster:
+
+```
+mqtt:topic:<Broker-Thing-ID>:<Thing-ID>:<Channel-ID>
+```
+
+- `mqtt:topic` — festes Präfix für MQTT-Topic-Things
+- `mosquitto` — die ID Ihres Broker-Things (wie in der .things-Datei definiert)
+- `pool-controller` — die ID Ihres Topic-Things
+- `poolTemp` — der Channel-Name aus der .things-Datei
+
+---
+
+## Schritt 6: Sitemap erstellen
+
+Sitemaps definieren, was in der openHAB BasicUI und den mobilen Apps angezeigt wird.
+
+Erstellen oder bearbeiten Sie `$OPENHAB_CONF/sitemaps/pool.sitemap`:
+
+```perl
+sitemap pool label="Pool Controller" {
+    Frame label="Steuerung" {
+        Switch item=Pool_OpMode label="Modus" icon="settings"
+            mappings=[auto="Auto", manu="Manuell", boost="Boost", timer="Timer"]
+
+        Text item=Pool_PoolPump label="Poolpumpe [%s]" icon="pump"
+            visibility=[Pool_OpMode==auto, Pool_OpMode==boost, Pool_OpMode==timer]
+        Switch item=Pool_PoolPump label="Poolpumpe" icon="pump"
+            visibility=[Pool_OpMode==manu]
+
+        Text item=Pool_SolarPump label="Solarpumpe [%s]" icon="solarplant"
+            visibility=[Pool_OpMode==auto, Pool_OpMode==boost, Pool_OpMode==timer]
+        Switch item=Pool_SolarPump label="Solarpumpe" icon="solarplant"
+            visibility=[Pool_OpMode==manu]
+    }
+
+    Frame label="Temperaturen" {
+        Text item=Pool_PoolTemp label="Pool [%.1f °C]" icon="temperature"
+            valuecolor=[>30="orange", >20="green", <=20="blue"]
+        Text item=Pool_SolarTemp label="Solar [%.1f °C]" icon="temperature"
+            valuecolor=[>30="orange", >20="green", <=20="blue"]
+    }
+
+    Frame label="Einstellungen" {
+        Frame label="Timer" {
+            Setpoint item=Pool_Timer_Start_H label="Start Std. [%.0f]" icon="time" minValue=0 maxValue=23 step=1
+            Setpoint item=Pool_Timer_Start_M label="Start Min. [%02.0f]" minValue=0 maxValue=59 step=5
+            Setpoint item=Pool_Timer_End_H label="Ende Std. [%.0f]" icon="time" minValue=0 maxValue=23 step=1
+            Setpoint item=Pool_Timer_End_M label="Ende Min. [%02.0f]" minValue=0 maxValue=59 step=5
+        }
+        Frame label="Konfiguration" {
+            Setpoint item=Pool_MaxTemp label="Max. Pooltemp. [%.0f °C]" icon="heating" minValue=0 maxValue=40 step=1
+            Setpoint item=Pool_MinSolarTemp label="Min. Solartemp. [%.0f °C]" icon="heating" minValue=0 maxValue=100 step=1
+            Setpoint item=Pool_Hysteresis label="Hysterese [%.1f K]" icon="line" minValue=0 maxValue=10 step=0.5
+        }
+        Frame label="System" {
+            Text item=Pool_Uptime label="Betriebszeit"
+            Text item=Pool_Signal label="WiFi-Signal [%.0f %%]"
+            Text item=Pool_FWVersion label="Firmware"
+        }
+    }
+}
+```
+
+---
+
+## Schritt 7: Funktion prüfen
+
+1. **Things prüfen**: Gehen Sie zu **Einstellungen → Things** in der openHAB-Oberfläche. Das `Pool Controller` Thing sollte **Online** anzeigen.
+2. **Items prüfen**: Öffnen Sie **Einstellungen → Items** und verifizieren Sie, dass alle Items vorhanden sind und Werte anzeigen.
+3. **Sitemap öffnen**: Navigieren Sie zu `http://<openhab-ip>:8080/basicui/app?sitemap=pool` oder nutzen Sie die openHAB-App.
+
+Wenn Items **NULL** oder **Nicht definiert** anzeigen:
+- Prüfen Sie, ob die MQTT-Topics mit den tatsächlichen Topics Ihres Controllers übereinstimmen (MQTT Explorer hilft beim Vergleichen)
+- Stellen Sie sicher, dass das Broker Thing Online ist
+- Überprüfen Sie `$OPENHAB_CONF/userdata/logs/openhab.log` auf MQTT-bezogene Fehler
+
+---
+
+## Konfigurationsdateien
+
+Die vollständige Referenzkonfiguration liegt im **[openhab-config Repository](https://github.com/smart-swimmingpool/openhab-config)** auf GitHub:
+
+| Datei | Zweck |
+|-------|-------|
+| [`things/mqtt.things`](https://github.com/smart-swimmingpool/openhab-config/blob/main/things/mqtt.things) | MQTT-Broker und Topic-Things |
+| [`items/2-pool.items`](https://github.com/smart-swimmingpool/openhab-config/blob/main/items/2-pool.items) | Item-Definitionen verknüpft mit Channels |
+| [`sitemaps/pool.sitemap`](https://github.com/smart-swimmingpool/openhab-config/blob/main/sitemaps/pool.sitemap) | BasicUI- und App-Layout |
+
+> **Hinweis**: Das openhab-config Repository verwendet derzeit **Homie 3.0** MQTT-Topics (für Controller v2.x). Wenn Sie Controller v3.x betreiben, passen Sie die Topics an das in dieser Anleitung gezeigte `homeassistant/`-Format an. Siehe dazu die [Firmware-Migration](/docs/firmware-migration/).
+
+---
+
+## Fehlerbehebung
+
+### Things bleiben OFFLINE
+
+- **Netzwerkverbindung prüfen**: Kann Ihr openHAB-Server den MQTT-Broker erreichen? (`ping <broker-ip>`)
+- **Zugangsdaten prüfen**: Wenn Ihr Broker eine Authentifizierung erfordert, verifizieren Sie Benutzername/Passwort im Broker-Thing
+- **Logs prüfen**: Führen Sie `tail -f $OPENHAB_CONF/userdata/logs/openhab.log | grep -i mqtt` für Echtzeit-Diagnose aus
+
+### Items zeigen "—" (kein Wert)
+
+- Die Topic-Namen in Ihrer `.things`-Datei stimmen möglicherweise nicht mit den tatsächlichen Topics des Controllers überein
+- Nutzen Sie MQTT Explorer, um `homeassistant/#` zu abonnieren und zu vergleichen
+- Der Controller sendet Zahlenwerte als einfache Zahlen (z. B. `25.5`) — keine Transformation erforderlich
+
+### Befehle erreichen den Controller nicht
+
+- Stellen Sie sicher, dass `commandTopic` in Ihrer `.things`-Datei für beschreibbare Channels angegeben ist
+- Prüfen Sie, ob der Controller mit dem MQTT-Broker verbunden ist (grüne LED oder Weboberfläche prüfen)
+- Testen Sie manuell: `mosquitto_pub -h <broker-ip> -t "homeassistant/switch/pool-controller/pool_pump/set" -m "ON"`
+
+### Falsche MQTT-Geräte-ID
+
+Die Standard-Geräte-ID ist `pool-controller`. Wenn Sie sie in der Weboberfläche des Controllers geändert haben (**Konfiguration → MQTT → Geräte-ID**), aktualisieren Sie alle Topic-Pfade in Ihrer `.things`-Datei entsprechend.

--- a/content/docs/openhab-integration/_index.md
+++ b/content/docs/openhab-integration/_index.md
@@ -1,0 +1,347 @@
+---
+title: openHAB Integration
+weight: 15
+tags: ["docs", "openHAB", "tutorial"]
+---
+
+**🏊 Smart Swimming Pool: Integrate the Pool Controller with openHAB**
+
+Unlike [Home Assistant](/docs/getting-started/#step-4-home-assistant-integration), which automatically discovers the pool controller via MQTT Discovery, openHAB requires **manual configuration**. This guide walks you through the process step by step.
+
+> 💡 **Already using openHAB?**  
+> The [openHAB Configuration](/docs/openhab-configuration/) page contains the complete reference files (Things, Items, Sitemap). This guide explains *how* to set them up and adapt them to your system.
+
+---
+
+## Prerequisites
+
+Before you begin, make sure you have:
+
+1. **The pool controller** flashed and running on your network (see [Getting Started](/docs/getting-started/))
+2. **An MQTT broker** (e.g., [Mosquitto](https://mosquitto.org/)) — install one on the same machine as openHAB or on your network
+3. **openHAB** (version 3 or 4) running and accessible via its web interface
+
+---
+
+## Step 1: Install the MQTT Binding
+
+In the openHAB web interface:
+
+1. Go to **Settings → Add-ons → Bindings**
+2. Search for **"MQTT"**
+3. Install the **MQTT Binding** (official binding by the openHAB project)
+4. No restart is required — the binding activates immediately
+
+---
+
+## Step 2: Configure the MQTT Broker Thing
+
+1. Go to **Settings → Things**
+2. Click **+** (Add Thing)
+3. Search for **"MQTT"** and select **MQTT Broker**
+4. Configure:
+   - **Host**: IP address of your MQTT broker (e.g., `192.168.1.100` or `core-mosquitto`)
+   - **Port**: `1883` (default, unencrypted)
+   - **Client ID**: `openHAB-pool` (must be unique on your broker)
+   - **Username/Password**: Only if your broker requires authentication
+5. Click **Create Thing**
+
+The Broker thing should come **Online** within seconds. If it doesn't, check that your MQTT broker is running and reachable.
+
+---
+
+## Step 3: Discover the MQTT Topics
+
+The pool controller v3.x publishes its data using [Home Assistant MQTT Discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery) format. You need to find the **exact topics** your controller publishes to configure openHAB correctly.
+
+### Option A: MQTT Explorer (Recommended)
+
+Install [MQTT Explorer](http://mqtt-explorer.com/) on your computer:
+
+1. Connect to your MQTT broker (host, port — same as above)
+2. Browse to the `homeassistant/` prefix
+3. You'll see topics organized by entity type:
+   ```
+   homeassistant/
+   ├── sensor/
+   │   └── pool-controller/
+   │       ├── pool_temp/
+   │       ├── solar_temp/
+   │       └── availability/
+   ├── switch/
+   │   └── pool-controller/
+   │       ├── pool_pump/
+   │       └── solar_pump/
+   ├── select/
+   │   └── pool-controller/
+   │       └── operation_mode/
+   └── number/
+       └── pool-controller/
+           ├── pool_max_temp/
+           ├── solar_min_temp/
+           ├── hysteresis/
+           ├── timer_start_h/
+           ├── timer_start_m/
+           ├── timer_end_h/
+           └── timer_end_m/
+   ```
+
+Each entity has:
+- `config` — discovery payload with metadata
+- `state` — current value
+- `set` — command topic (for writable entities)
+
+### Option B: Command Line (mosquitto_sub)
+
+If you prefer the terminal:
+
+```bash
+# Subscribe to all pool controller topics
+mosquitto_sub -h <broker-ip> -t "homeassistant/#" -v
+
+# Or filter for pool controller specifically
+mosquitto_sub -h <broker-ip> -t "homeassistant/+/pool-controller/#" -v
+```
+
+> ⚠️ **Note**: Your controller's device ID may differ from `pool-controller` if you changed the **MQTT Device ID** in the pool controller's web interface. Adjust the topic prefix accordingly.
+
+---
+
+## Step 4: Create a Thing File
+
+openHAB 3+ uses **`.things` files** in `$OPENHAB_CONF/things/` to define MQTT topic Things.
+
+Create `$OPENHAB_CONF/things/pool-controller.things`:
+
+```java
+Bridge mqtt:broker:mosquitto "Mosquitto" [ host="127.0.0.1", port=1883, secure=false, clientID="openHAB-pool" ]
+{
+    Thing topic pool-controller "Pool Controller" @ "Outside" {
+        Channels:
+            // Operation Mode
+            Type string : operationMode "Operation Mode"
+                [ stateTopic="homeassistant/select/pool-controller/operation_mode/state",
+                  commandTopic="homeassistant/select/pool-controller/operation_mode/set" ]
+
+            // Configuration Numbers
+            Type number : maxPoolTemp "Max Pool Temperature"
+                [ stateTopic="homeassistant/number/pool-controller/pool_max_temp/state",
+                  commandTopic="homeassistant/number/pool-controller/pool_max_temp/set" ]
+            Type number : minSolarTemp "Min Solar Temperature"
+                [ stateTopic="homeassistant/number/pool-controller/solar_min_temp/state",
+                  commandTopic="homeassistant/number/pool-controller/solar_min_temp/set" ]
+            Type number : hysteresis "Hysteresis"
+                [ stateTopic="homeassistant/number/pool-controller/hysteresis/state",
+                  commandTopic="homeassistant/number/pool-controller/hysteresis/set" ]
+            Type number : timerStartH "Timer Start Hour"
+                [ stateTopic="homeassistant/number/pool-controller/timer_start_h/state",
+                  commandTopic="homeassistant/number/pool-controller/timer_start_h/set" ]
+            Type number : timerStartM "Timer Start Minute"
+                [ stateTopic="homeassistant/number/pool-controller/timer_start_m/state",
+                  commandTopic="homeassistant/number/pool-controller/timer_start_m/set" ]
+            Type number : timerEndH "Timer End Hour"
+                [ stateTopic="homeassistant/number/pool-controller/timer_end_h/state",
+                  commandTopic="homeassistant/number/pool-controller/timer_end_h/set" ]
+            Type number : timerEndM "Timer End Minute"
+                [ stateTopic="homeassistant/number/pool-controller/timer_end_m/state",
+                  commandTopic="homeassistant/number/pool-controller/timer_end_m/set" ]
+
+            // Pumps
+            Type switch : poolPump "Pool Pump"
+                [ stateTopic="homeassistant/switch/pool-controller/pool_pump/state",
+                  commandTopic="homeassistant/switch/pool-controller/pool_pump/set" ]
+            Type switch : solarPump "Solar Pump"
+                [ stateTopic="homeassistant/switch/pool-controller/solar_pump/state",
+                  commandTopic="homeassistant/switch/pool-controller/solar_pump/set" ]
+
+            // Temperatures
+            Type number : poolTemp "Pool Temperature"
+                [ stateTopic="homeassistant/sensor/pool-controller/pool_temp/state" ]
+            Type number : solarTemp "Solar Temperature"
+                [ stateTopic="homeassistant/sensor/pool-controller/solar_temp/state" ]
+
+            // System Info
+            Type number : signal "WiFi Signal"
+                [ stateTopic="homeassistant/sensor/pool-controller/signal/state" ]
+            Type number : uptime "Uptime"
+                [ stateTopic="homeassistant/sensor/pool-controller/uptime/state" ]
+            Type string : fwVersion "Firmware Version"
+                [ stateTopic="homeassistant/sensor/pool-controller/fw_version/state" ]
+    }
+}
+```
+
+> **Replace `pool-controller`** in the topic paths with your actual device ID if you changed it.
+
+---
+
+## Step 5: Create an Items File
+
+Items link the MQTT channels to openHAB items that can be displayed on UIs and used in rules.
+
+Create `$OPENHAB_CONF/items/pool-controller.items`:
+
+```java
+// Groups
+Group gPool_Controller "Pool Controller" <swimmingpool>
+
+// Operation Mode
+String Pool_OpMode "Operation Mode [%s]" <settings> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:operationMode", autoupdate="true" }
+
+// Configuration
+Number Pool_MaxTemp "Max Pool Temp [%.1f °C]" <heating> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:maxPoolTemp", autoupdate="true" }
+Number Pool_MinSolarTemp "Min Solar Temp [%.1f °C]" <heating> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:minSolarTemp", autoupdate="true" }
+Number Pool_Hysteresis "Hysteresis [%.1f K]" <line> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:hysteresis", autoupdate="true" }
+
+Number Pool_Timer_Start_H "Timer Start Hour [%.0f h]" <time> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:timerStartH", autoupdate="true" }
+Number Pool_Timer_Start_M "Timer Start Min [%.0f m]" <time> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:timerStartM", autoupdate="true" }
+Number Pool_Timer_End_H "Timer End Hour [%.0f h]" <time> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:timerEndH", autoupdate="true" }
+Number Pool_Timer_End_M "Timer End Min [%.0f m]" <time> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:timerEndM", autoupdate="true" }
+
+// Pumps
+Switch Pool_PoolPump "Pool Pump" <pump> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:poolPump", autoupdate="false" }
+Switch Pool_SolarPump "Solar Pump" <solarplant> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:solarPump", autoupdate="false" }
+
+// Temperatures
+Number Pool_PoolTemp "Pool Temperature [%.1f °C]" <temperature> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:poolTemp", autoupdate="false" }
+Number Pool_SolarTemp "Solar Temperature [%.1f °C]" <temperature> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:solarTemp", autoupdate="false" }
+
+// System
+Number Pool_Signal "WiFi Signal [%.0f%%]" <network> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:signal", autoupdate="false" }
+Number Pool_Uptime "Uptime [%d s]" <time> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:uptime", autoupdate="false" }
+String Pool_FWVersion "Firmware [%s]" <text> (gPool_Controller)
+    { channel="mqtt:topic:mosquitto:pool-controller:fwVersion", autoupdate="false" }
+```
+
+### Channel UID Format
+
+The channel UID follows this pattern:
+
+```
+mqtt:topic:<broker-thing-id>:<thing-id>:<channel-id>
+```
+
+- `mqtt:topic` — fixed prefix for MQTT topic Things
+- `mosquitto` — your broker Thing's ID (as defined in the .things file)
+- `pool-controller` — your topic Thing's ID
+- `poolTemp` — the channel name from the .things file
+
+---
+
+## Step 6: Create a Sitemap
+
+Sitemaps define what appears on the openHAB BasicUI and mobile apps.
+
+Create or edit `$OPENHAB_CONF/sitemaps/pool.sitemap`:
+
+```perl
+sitemap pool label="Pool Controller" {
+    Frame label="Control" {
+        Switch item=Pool_OpMode label="Mode" icon="settings"
+            mappings=[auto="Auto", manu="Manual", boost="Boost", timer="Timer"]
+
+        Text item=Pool_PoolPump label="Pool Pump [%s]" icon="pump"
+            visibility=[Pool_OpMode==auto, Pool_OpMode==boost, Pool_OpMode==timer]
+        Switch item=Pool_PoolPump label="Pool Pump" icon="pump"
+            visibility=[Pool_OpMode==manu]
+
+        Text item=Pool_SolarPump label="Solar Pump [%s]" icon="solarplant"
+            visibility=[Pool_OpMode==auto, Pool_OpMode==boost, Pool_OpMode==timer]
+        Switch item=Pool_SolarPump label="Solar Pump" icon="solarplant"
+            visibility=[Pool_OpMode==manu]
+    }
+
+    Frame label="Temperatures" {
+        Text item=Pool_PoolTemp label="Pool [%.1f °C]" icon="temperature"
+            valuecolor=[>30="orange", >20="green", <=20="blue"]
+        Text item=Pool_SolarTemp label="Solar [%.1f °C]" icon="temperature"
+            valuecolor=[>30="orange", >20="green", <=20="blue"]
+    }
+
+    Frame label="Settings" {
+        Frame label="Timer" {
+            Setpoint item=Pool_Timer_Start_H label="Start Hour [%.0f]" icon="time" minValue=0 maxValue=23 step=1
+            Setpoint item=Pool_Timer_Start_M label="Start Minute [%02.0f]" minValue=0 maxValue=59 step=5
+            Setpoint item=Pool_Timer_End_H label="End Hour [%.0f]" icon="time" minValue=0 maxValue=23 step=1
+            Setpoint item=Pool_Timer_End_M label="End Minute [%02.0f]" minValue=0 maxValue=59 step=5
+        }
+        Frame label="Configuration" {
+            Setpoint item=Pool_MaxTemp label="Max Pool Temp [%.0f °C]" icon="heating" minValue=0 maxValue=40 step=1
+            Setpoint item=Pool_MinSolarTemp label="Min Solar Temp [%.0f °C]" icon="heating" minValue=0 maxValue=100 step=1
+            Setpoint item=Pool_Hysteresis label="Hysteresis [%.1f K]" icon="line" minValue=0 maxValue=10 step=0.5
+        }
+        Frame label="System" {
+            Text item=Pool_Uptime label="Uptime"
+            Text item=Pool_Signal label="WiFi Signal [%.0f %%]"
+            Text item=Pool_FWVersion label="Firmware"
+        }
+    }
+}
+```
+
+---
+
+## Step 7: Verify Everything Works
+
+1. **Check Things**: Go to **Settings → Things** in the openHAB UI. The `Pool Controller` Thing should show **Online**.
+2. **Check Items**: Open **Settings → Items** and verify all items are present with values.
+3. **Open the Sitemap**: Navigate to `http://<openhab-ip>:8080/basicui/app?sitemap=pool` or use the openHAB mobile app.
+
+If items show as **NULL** or **Undefined**:
+- Verify the MQTT topics match what your controller publishes (use MQTT Explorer to double-check)
+- Ensure the broker Thing is Online
+- Check `$OPENHAB_CONF/userdata/logs/openhab.log` for MQTT-related errors
+
+---
+
+## Configuration Files
+
+The complete reference configuration lives in the **[openhab-config repository](https://github.com/smart-swimmingpool/openhab-config)** on GitHub:
+
+| File | Purpose |
+|------|---------|
+| [`things/mqtt.things`](https://github.com/smart-swimmingpool/openhab-config/blob/main/things/mqtt.things) | MQTT Broker and Topic Things |
+| [`items/2-pool.items`](https://github.com/smart-swimmingpool/openhab-config/blob/main/items/2-pool.items) | Item definitions linked to channels |
+| [`sitemaps/pool.sitemap`](https://github.com/smart-swimmingpool/openhab-config/blob/main/sitemaps/pool.sitemap) | BasicUI and mobile app layout |
+
+> **Note**: The openhab-config repository currently references **Homie 3.0** MQTT topics (for controller v2.x). If you are running controller v3.x, adapt the topics to the `homeassistant/` format shown in this guide. See the [Firmware Migration](/docs/firmware-migration/) guide for details.
+
+---
+
+## Troubleshooting
+
+### Things stay OFFLINE
+
+- **Check network connectivity**: Can your openHAB server reach the MQTT broker? (`ping <broker-ip>`)
+- **Check credentials**: If your broker requires authentication, verify username/password in the Broker Thing
+- **Check the logs**: Run `tail -f $OPENHAB_CONF/userdata/logs/openhab.log | grep -i mqtt` for real-time diagnostics
+
+### Items show "—" (no value)
+
+- The topic names in your `.things` file might not match the controller's actual topics
+- Use MQTT Explorer to subscribe to `homeassistant/#` and compare
+- The controller publishes numeric values as plain numbers (e.g., `25.5`) — no transformation is needed
+
+### Commands don't reach the controller
+
+- Verify that `commandTopic` is specified in your `.things` file for writable channels
+- Check that the controller is connected to the MQTT broker (green LED on, or check the web interface)
+- Test manually: `mosquitto_pub -h <broker-ip> -t "homeassistant/switch/pool-controller/pool_pump/set" -m "ON"`
+
+### Wrong MQTT Device ID
+
+The default device ID is `pool-controller`. If you changed it in the controller's web interface (**Configuration → MQTT → Device ID**), update all topic paths in your `.things` file to match.


### PR DESCRIPTION
## Summary

Adds the **openHAB Integration Guide** — a comprehensive step-by-step guide for integrating the Pool Controller v3.x with openHAB, since openHAB does not support automatic MQTT Discovery like Home Assistant.

## Changes

### New files
- `content/docs/openhab-integration/_index.md` — EN guide (347 lines)
- `content/docs/openhab-integration/_index.de.md` — DE guide (347 lines)

### Modified files
- `content/_index.md` / `_index.de.md` — Homepage card now links to Integration Guide
- `content/docs/_index.md` / `_index.de.md` — Added Integration entry in module list
- `content/docs/getting-started/_index.md` / `_index.de.md` — Updated 'What's Next' section

## What the guide covers
1. **Prerequisites** — MQTT broker, openHAB MQTT Binding
2. **Topic discovery** — MQTT Explorer / mosquitto_sub
3. **Thing file** — Complete .things with homeassistant/ format topics
4. **Items file** — Full .items with channel bindings
5. **Sitemap** — BasicUI and mobile app layout
6. **Troubleshooting** — Common issues and solutions

This is **Phase 2** of the documentation rework (after Home Assistant auto-discovery in Phase 1). The Integration Guide complements the existing `openhab-configuration` imported docs by providing setup instructions rather than raw config file references.