### PR TITLE
docs: add Home Assistant Integration Guide

### DIFF
--- a/content/docs/_index.de.md
+++ b/content/docs/_index.de.md
@@ -11,6 +11,8 @@ Dieses Projekt ist in verschiedene Module aufgeteilt:
 
 - **[Pool Controller](/docs/pool-controller/)**:
   Das Herz der Steuerung — zentrale Steuerlogik auf ESP32-Basis.
+- **[Home Assistant Integration](/docs/home-assistant-integration/)**:
+  Automatischer MQTT Discovery — der einfachste Weg zur Integration in Home Assistant.
 - **[openHAB Integration](/docs/openhab-integration/)**:
   Schritt-für-Schritt-Anleitung zur Integration des Pool Controllers mit openHAB.
 - **[openHAB Konfiguration](/docs/openhab-configuration/)**:

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -11,6 +11,8 @@ This project is split into several modules:
 
 - **[Pool Controller](/docs/pool-controller/)**:
   The heart of the 🏊 Smart Swimming Pool — ESP32-based central control logic.
+- **[Home Assistant Integration](/docs/home-assistant-integration/)**:
+  Automatic MQTT Discovery — the easiest way to integrate with Home Assistant.
 - **[openHAB Integration](/docs/openhab-integration/)**:
   Step-by-step guide to integrate the Pool Controller with openHAB.
 - **[openHAB Configuration](/docs/openhab-configuration/)**:

--- a/content/docs/getting-started/_index.de.md
+++ b/content/docs/getting-started/_index.de.md
@@ -153,11 +153,9 @@ Wenn Sie Home Assistant mit MQTT verwenden:
 2. In Home Assistant gehen Sie zu **Einstellungen → Geräte & Dienste**.
 3. Klicken Sie auf **Integration hinzufügen → MQTT** (falls nicht schon konfiguriert).
 4. Der Pool Controller sollte automatisch als neues Gerät erscheinen.
-5. Sie sehen Entitäten für:
-   - Temperaturen (Pool, Solar, Außen)
-   - Umwälzpumpen-Schalter
-   - Heizkreisschalter
-   - Systemstatus-Sensoren
+5. Alle Sensoren, Steuerungen und Konfigurationsparameter erscheinen als Entities — keine manuelle Einrichtung nötig.
+
+> ▶️ **Ausführliche Anleitung**: Siehe [Home Assistant Integrations-Guide](/docs/home-assistant-integration/) für die vollständige Entity-Referenz, Dashboard-Einrichtung, Automatisierungsbeispiele und Fehlerbehebung.
 
 ### Schritt 5: Pumpen anschließen
 
@@ -177,6 +175,7 @@ Die Erste-Schritte-Anleitung konzentriert sich auf den **Pool Controller** als z
 | Modul | Zweck | Wann hinzufügen |
 |-------|-------|-----------------|
 | **Pool Controller** (diese Anleitung) | Hauptsteuerung: Pumpen, Heizung, Zirkulation | Erforderlich — hier starten |
+| **Home Assistant** | Nativer MQTT Discovery | Automatisch — keine Einrichtung nötig |
 | **Pool Monitor** | Solarbetriebene Temperaturanzeige | Nachdem der Controller läuft |
 | **Grafana Dashboard** | Datenvisualisierung und -verlauf | Wenn Sie historische Diagramme möchten |
 | **openHAB Konfiguration** | Integration mit openHAB | Wenn Sie openHAB statt Home Assistant nutzen |
@@ -185,6 +184,7 @@ Die Erste-Schritte-Anleitung konzentriert sich auf den **Pool Controller** als z
 ## Wie geht es weiter?
 
 Sobald Ihr Pool Controller läuft:
+- Entdecken Sie den **[Home Assistant Integrations-Guide](/docs/home-assistant-integration/)** für die vollständige Entity-Referenz, Dashboard-Einrichtung und Automatisierungsbeispiele
 - Richten Sie das **[Grafana Dashboard](/docs/grafana-dashboard/)** für Temperaturverläufe ein
 - Fügen Sie den **[Pool Monitor](/docs/pool-monitor/)** für ein eigenes Display hinzu
 - Besuchen Sie das **[FAQ](/docs/troubleshooting/)** bei Problemen

--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -153,11 +153,9 @@ If you use Home Assistant with MQTT configured:
 2. In Home Assistant, go to **Settings → Devices & Services**.
 3. Click **Add Integration → MQTT** (if not already configured).
 4. The pool controller should appear as a new device automatically.
-5. You'll see entities for:
-   - Temperatures (pool, solar, outside)
-   - Circulation pump switch
-   - Heating circuit switch
-   - System status sensors
+5. All sensors, controls, and configuration parameters appear as entities — no manual setup needed.
+
+> ▶️ **Detailed guide**: See the [Home Assistant Integration Guide](/docs/home-assistant-integration/) for the complete entity reference, dashboard setup, automation examples, and troubleshooting.
 
 ### Step 5: Connect the Pumps
 
@@ -177,6 +175,7 @@ The Getting Started guide focuses on the **Pool Controller**, which is the centr
 | Module | Purpose | When to Add |
 |--------|---------|-------------|
 | **Pool Controller** (this guide) | Main control: pumps, heating, circulation | Required — start here |
+| **Home Assistant** | Native MQTT Discovery integration | Automatic — no setup needed |
 | **Pool Monitor** | Solar-powered wireless temperature display | After controller is running |
 | **Grafana Dashboard** | Data visualization and history | When you want historical charts |
 | **openHAB Configuration** | Integration with openHAB smart home | If you use openHAB instead of Home Assistant |
@@ -185,6 +184,7 @@ The Getting Started guide focuses on the **Pool Controller**, which is the centr
 ## What's Next?
 
 Once your Pool Controller is running:
+- Explore the **[Home Assistant Integration Guide](/docs/home-assistant-integration/)** for the complete entity reference, dashboard setup, and automation examples
 - Set up the **[Grafana Dashboard](/docs/grafana-dashboard/)** to visualize temperature trends
 - Add the **[Pool Monitor](/docs/pool-monitor/)** for a dedicated display
 - Check the **[FAQ](/docs/troubleshooting/)** if you run into issues

--- a/content/docs/home-assistant-integration/_index.de.md
+++ b/content/docs/home-assistant-integration/_index.de.md
@@ -1,0 +1,308 @@
+---
+title: Home Assistant Integration
+weight: 14
+tags: ["docs", "home-assistant", "tutorial"]
+---
+
+**🏊 Smart Swimming Pool: Den Pool Controller mit Home Assistant integrieren**
+
+Der Pool Controller v3.x integriert sich über **nativen [MQTT Discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery)** in Home Assistant. Sobald der Controller mit Ihrem MQTT-Broker verbunden ist, registriert er automatisch alle Sensoren, Steuerungen und Konfigurationsparameter als Home-Assistant-Entities — keine manuelle Konfiguration erforderlich.
+
+> 💡 **Sie richten den Pool Controller zum ersten Mal ein?**  
+> Folgen Sie zuerst der [Erste Schritte](/docs/getting-started/)-Anleitung, die das Flashen der Firmware, die WiFi-Konfiguration und die MQTT-Einrichtung abdeckt.
+
+---
+
+## Voraussetzungen
+
+Bevor der Pool Controller in Home Assistant erscheint:
+
+1. **Home Assistant** mit konfigurierter **[MQTT-Integration](https://www.home-assistant.io/integrations/mqtt/)** (Broker-Verbindung)
+2. **Pool Controller** mit dem **gleichen MQTT-Broker** verbunden (konfiguriert über die Weboberfläche: **Konfiguration → MQTT**)
+3. **MQTT Discovery aktiviert** in Home Assistant (`discovery: true` in `configuration.yaml` — standardmäßig aktiviert)
+
+---
+
+## Funktionsweise
+
+Beim Start und bei der MQTT-Verbindung veröffentlicht der Pool Controller **Discovery-Payloads** auf Topics wie:
+
+```
+homeassistant/sensor/pool-controller/pool-temp/config
+homeassistant/switch/pool-controller/pool-pump/config
+homeassistant/select/pool-controller/mode/config
+...
+```
+
+Home Assistant hört standardmäßig auf `homeassistant/+/+/config` und erstellt automatisch Entities aus diesen Payloads. Alle Entities werden unter einem einzigen **Pool Controller**-Gerät gruppiert.
+
+### Geräteinformationen
+
+Der Controller identifiziert sich mit:
+
+| Eigenschaft | Wert |
+|-------------|------|
+| **Name** | Pool Controller |
+| **Hersteller** | smart-swimmingpool |
+| **Modell** | Pool Controller |
+| **Identifikator** | `pool_controller_<mac-suffix>` (pro Gerät eindeutig) |
+
+---
+
+## Vollständige Entity-Referenz
+
+Sobald der Pool Controller verbunden ist, erstellt er folgende Entities in Home Assistant:
+
+### 📊 Primäre Sensoren
+
+Diese erscheinen auf der Gerätevorderseite (kein `entity_category`):
+
+| Entity-ID | Name | Geräteklasse | Einheit |
+|-----------|------|-------------|---------|
+| `sensor.pool_controller_pool_temp` | Pool Temperature | `temperature` | °C |
+| `sensor.pool_controller_solar_temp` | Solar Temperature | `temperature` | °C |
+
+### 🛠️ Steuerungen (Schalter & Auswahl)
+
+| Entity-ID | Name | Typ | Hinweis |
+|-----------|------|-----|---------|
+| `switch.pool_controller_pool_pump` | Pool Pump | Schalter | Nur im **Manuell**-Modus beschreibbar |
+| `switch.pool_controller_solar_pump` | Solar Pump | Schalter | Nur im **Manuell**-Modus beschreibbar |
+| `select.pool_controller_mode` | Operation Mode | Auswahl | Optionen: auto, manu, boost, timer |
+
+### 🔧 Konfigurationsparameter (`entity_category: config`)
+
+| Entity-ID | Name | Typ | Einheit | Bereich |
+|-----------|------|-----|---------|--------|
+| `number.pool_controller_pool_max_temp` | Max. Pool Temp | Zahl | °C | 0–40 |
+| `number.pool_controller_solar_min_temp` | Min. Solar Temp | Zahl | °C | 0–100 |
+| `number.pool_controller_hysteresis` | Temperature Hysteresis | Zahl | K | 0–10 |
+| `number.pool_controller_temp_circ_threshold` | Circ. Temp Threshold | Zahl | °C | 0–40 |
+| `number.pool_controller_temp_circ_factor` | Circ. Temp Factor | Zahl | min/°C | 0–120 |
+| `number.pool_controller_temp_circ_max_runtime` | Circ. Max Runtime | Zahl | min | 60–1440 |
+| `time.pool_controller_timer_start` | Timer Start | Zeit | — | HH:MM:SS |
+| `time.pool_controller_timer_end` | Timer End | Zeit | — | HH:MM:SS |
+| `select.pool_controller_timezone` | Timezone | Auswahl | — | (dynamische Liste) |
+| `text.pool_controller_ntp_server` | NTP Server | Text | — | — |
+| `update.pool_controller_firmware` | Firmware | Update | — | — |
+| `climate.pool_controller_thermostat` | Pool Thermostat | Climate | °C | 0–40 |
+
+Die **Climate**-Entity (`climate.pool_controller_thermostat`) bietet eine thermostatähnliche Steuerung:
+- **HVAC-Modi**: aus, auto, heizen
+- **Aktuelle Temperatur**: Pool-Wassertemperatur
+- **Zieltemperatur**: entspricht der Max. Pool Temp
+- **Aktion**: heizen, bereit, aus
+
+### 🔍 Diagnose (`entity_category: diagnostic`)
+
+| Entity-ID | Name | Geräteklasse | Einheit |
+|-----------|------|-------------|---------|
+| `sensor.pool_controller_controller_temp` | Controller Temperature | `temperature` | °C |
+| `sensor.pool_controller_heap` | Free Heap Space | — | B |
+| `sensor.pool_controller_max_alloc` | Max Alloc Block | — | B |
+| `sensor.pool_controller_rssi` | WiFi Signal Strength | — | dBm |
+| `sensor.pool_controller_uptime` | System Uptime | `duration` | s |
+| `sensor.pool_controller_local_time` | Local Time | — | — |
+| `sensor.pool_controller_effective_runtime` | Effective Runtime | `duration` | s |
+| `sensor.pool_controller_solar_sensor_found` | Solar Sensor Found | — | Gefunden/Fehlt |
+| `sensor.pool_controller_pool_sensor_found` | Pool Sensor Found | — | Gefunden/Fehlt |
+
+### 🧭 Sensor-Zuordnung (Konfiguration)
+
+| Entity-ID | Name | Typ | Zweck |
+|-----------|------|-----|-------|
+| `select.pool_controller_solar_sensor` | Solar Sensor | Auswahl | Bestimmten DS18B20 als Solarsensor zuweisen |
+| `select.pool_controller_pool_sensor` | Pool Sensor | Auswahl | Bestimmten DS18B20 als Poolsensor zuweisen |
+
+Diese Auswahl-Entities listen alle erkannten DS18B20-Adressen auf dem OneWire-Bus auf. Verwenden Sie sie, um einen bestimmten Sensor der Solar- oder Pool-Rolle zuzuordnen, wenn mehrere Sensoren angeschlossen sind.
+
+> **Tipp**: Überprüfen Sie nach der Auswahl eines Sensors `sensor.pool_controller_solar_sensor_found` und `sensor.pool_controller_pool_sensor_found`, um zu bestätigen, dass der Sensor erkannt wird.
+
+---
+
+## Dashboard erstellen (Lovelace)
+
+### Option A: Gerät automatisch hinzufügen
+
+1. Gehen Sie zu **Einstellungen → Geräte & Dienste → Geräte**
+2. Suchen Sie **Pool Controller** in der Geräteliste
+3. Klicken Sie bei jeder gewünschten Entity auf **Zu Lovelace hinzufügen**
+
+### Option B: Manuelle Lovelace-Konfiguration
+
+Erstellen Sie eine Ansicht in Ihrer `ui-lovelace.yaml` oder über den Lovelace-UI-Editor:
+
+```yaml
+type: vertical-stack
+cards:
+  - type: entities
+    title: Pool Controller
+    entities:
+      - entity: sensor.pool_controller_pool_temp
+      - entity: sensor.pool_controller_solar_temp
+      - entity: select.pool_controller_mode
+      - entity: switch.pool_controller_pool_pump
+      - entity: switch.pool_controller_solar_pump
+      - entity: sensor.pool_controller_uptime
+
+  - type: entities
+    title: Konfiguration
+    entities:
+      - entity: number.pool_controller_pool_max_temp
+      - entity: number.pool_controller_solar_min_temp
+      - entity: number.pool_controller_hysteresis
+      - entity: time.pool_controller_timer_start
+      - entity: time.pool_controller_timer_end
+
+  - type: thermostat
+    entity: climate.pool_controller_thermostat
+
+  - type: entities
+    title: Diagnose
+    state_color: true
+    entities:
+      - entity: sensor.pool_controller_rssi
+      - entity: sensor.pool_controller_controller_temp
+      - entity: sensor.pool_controller_effective_runtime
+      - entity: sensor.pool_controller_solar_sensor_found
+      - entity: sensor.pool_controller_pool_sensor_found
+```
+
+### Option C: Standard-Dashboard nutzen
+
+Der Controller erstellt Entities in der standardmäßigen **MQTT-Gerätegruppe**. Öffnen Sie **Übersicht** → klicken Sie auf die drei Punkte → **Dashboard bearbeiten** → **Karte hinzufügen** → suchen Sie nach "Pool Controller", um einzelne Entities hinzuzufügen.
+
+---
+
+## Automatisierungsbeispiele
+
+### Benachrichtigung bei Zieltemperatur
+
+```yaml
+alias: "Pool Temperatur Alarm"
+triggers:
+  - trigger: numeric_state
+    entity_id: sensor.pool_controller_pool_temp
+    above: 28
+actions:
+  - action: notify.mobile_app
+    data:
+      title: "Pool ist warm! 🏊"
+      message: "Pooltemperatur: {{ states('sensor.pool_controller_pool_temp') }}°C"
+```
+
+### Heizung nachts ausschalten
+
+```yaml
+alias: "Pool Heizung Nacht Aus"
+triggers:
+  - trigger: time
+    at: "22:00:00"
+conditions:
+  - condition: state
+    entity_id: select.pool_controller_mode
+    state: auto
+actions:
+  - action: select.select_option
+    target:
+      entity_id: select.pool_controller_mode
+    data:
+      option: timer
+```
+
+### Neustart bei Offline-Erkennung
+
+```yaml
+alias: "Pool Controller Offline Warnung"
+triggers:
+  - trigger: state
+    entity_id: sensor.pool_controller_uptime
+    to: unavailable
+    for:
+      minutes: 5
+actions:
+  - action: notify.mobile_app
+    data:
+      title: "⚠️ Pool Controller Offline"
+      message: "Pool Controller seit 5 Minuten nicht erreichbar"
+```
+
+### Temperaturabhängige Solarzirkulation
+
+Die temperaturbasierte Zirkulation nutzt die Parameter des Controllers (v3.3+):
+
+```yaml
+alias: "Solarzirkulation - Voll"
+triggers:
+  - trigger: time_pattern
+    minutes: "/15"
+conditions:
+  - condition: numeric_state
+    entity_id: sensor.pool_controller_solar_temp
+    above: 30
+  - condition: numeric_state
+    entity_id: number.pool_controller_pool_max_temp
+    below: "{{ states('sensor.pool_controller_pool_temp') | float }}"
+actions:
+  - action: switch.turn_on
+    target:
+      entity_id: switch.pool_controller_solar_pump
+```
+
+---
+
+## Firmware-Updates über HA
+
+Der Pool Controller stellt eine **Update**-Entity (`update.pool_controller_firmware`) in Home Assistant bereit:
+
+1. Gehen Sie zu **Einstellungen → Geräte & Dienste → Geräte → Pool Controller**
+2. Die **Firmware**-Entity zeigt die aktuelle vs. neueste Version
+3. Klicken Sie auf **Installieren**, um ein OTA-Update auszulösen
+4. Der Controller lädt das Update herunter und startet automatisch neu
+
+> **Hinweis**: Firmware-Updates erfordern eine Internetverbindung auf dem ESP32 und mindestens 2 MB freien Flash-Speicher.
+
+---
+
+## Fehlerbehebung
+
+### Pool Controller erscheint nicht in Home Assistant
+
+1. **MQTT-Broker-Verbindung prüfen**: Ist der Controller als verbunden auf dem MQTT-Broker sichtbar? (Prüfen Sie das Topic `homeassistant/sensor/pool-controller/availability` — Payload sollte `online` sein)
+2. **MQTT-Integration prüfen**: Gehen Sie zu **Einstellungen → Geräte & Dienste → Integrationen → MQTT** und bestätigen Sie die Konfiguration
+3. **MQTT Discovery aktiviert**: In `configuration.yaml`:
+   ```yaml
+   mqtt:
+     discovery: true
+   ```
+4. **MQTT in HA neu starten**: Gehen Sie zu **Einstellungen → System → Dienste neu starten**
+5. **Controller neustarten**: ESP32 stromlos schalten oder den Neustart-Knopf in der Weboberfläche verwenden
+
+### Entities zeigen "Nicht verfügbar"
+
+- Der Controller ist möglicherweise offline. Prüfen Sie das oben genannte `availability`-Topic
+- Es könnten veraltete retain-Nachrichten vorhanden sein. Veröffentlichen Sie eine leere Payload auf dem `/config`-Topic der Entity, um veraltete Discovery zu löschen
+- Prüfen Sie `homeassistant/sensor/pool-controller/availability` — es sollte eine retained `online`-Nachricht enthalten
+
+### Pumpenschalter lassen sich nicht umschalten
+
+Der Pool Controller **akzeptiert Pumpenbefehle nur im Manuell-Modus**. Wenn der Controller im Auto-, Boost- oder Timer-Modus ist, werden Pumpenbefehle von Home Assistant ignoriert.
+
+Zum Umschalten der Pumpen:
+1. Setzen Sie die **Operation Mode**-Auswahl auf `manu` (Manuell)
+2. Jetzt sind die Schalter-Entities beschreibbar
+3. Nach der manuellen Steuerung zurück auf `auto` oder einen anderen Modus schalten
+
+### Zahlenwerte aktualisieren sich nicht
+
+- Der Controller akzeptiert Konfigurationsänderungen (Temperaturgrenzen, Hysterese usw.) **in jedem Modus**
+- Änderungen werden im Flash-Speicher des Controllers gespeichert
+- Wenn Werte zurückgesetzt werden, prüfen Sie die Weboberfläche des Controllers: **Status → Letzter Fehler**
+
+### Sensorzuordnung zeigt keine Optionen
+
+Die Entities `select.pool_controller_solar_sensor` und `select.pool_controller_pool_sensor` werden erst befüllt, nachdem der Controller seinen OneWire-Bus-Scan abgeschlossen hat. Dies geschieht:
+- Beim Start (nachdem WiFi verbunden ist)
+- Wenn Sie in der Weboberfläche auf **Neu scannen** klicken
+
+Wenn keine DS18B20-Sensoren angeschlossen sind, zeigen diese Entities nur die Option `— Not configured —` an.

--- a/content/docs/home-assistant-integration/_index.md
+++ b/content/docs/home-assistant-integration/_index.md
@@ -1,0 +1,308 @@
+---
+title: Home Assistant Integration
+weight: 14
+tags: ["docs", "home-assistant", "tutorial"]
+---
+
+**🏊 Smart Swimming Pool: Integrate the Pool Controller with Home Assistant**
+
+The Pool Controller v3.x integrates with Home Assistant through **native [MQTT Discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery)**. When connected to your MQTT broker, the controller automatically registers all its sensors, controls, and configuration parameters as Home Assistant entities — no manual configuration required.
+
+> 💡 **First time setting up the pool controller?**  
+> Follow the [Getting Started](/docs/getting-started/) guide first, which covers flashing the firmware, WiFi configuration, and MQTT setup.
+
+---
+
+## Prerequisites
+
+Before the pool controller can appear in Home Assistant:
+
+1. **Home Assistant** with the **[MQTT integration](https://www.home-assistant.io/integrations/mqtt/)** configured (broker connection)
+2. **Pool Controller** connected to the **same MQTT broker** (configured via its web interface: **Configuration → MQTT**)
+3. **MQTT Discovery enabled** in Home Assistant (`discovery: true` in `configuration.yaml` — enabled by default)
+
+---
+
+## How It Works
+
+On startup and when MQTT connects, the pool controller publishes **discovery payloads** to topics like:
+
+```
+homeassistant/sensor/pool-controller/pool-temp/config
+homeassistant/switch/pool-controller/pool-pump/config
+homeassistant/select/pool-controller/mode/config
+...
+```
+
+Home Assistant listens on `homeassistant/+/+/config` by default, automatically creating entities from these payloads. All entities are grouped under a single **Pool Controller** device.
+
+### Device Info
+
+The controller identifies itself with:
+
+| Property | Value |
+|----------|-------|
+| **Name** | Pool Controller |
+| **Manufacturer** | smart-swimmingpool |
+| **Model** | Pool Controller |
+| **Identifiers** | `pool_controller_<mac-suffix>` (unique per device) |
+
+---
+
+## Complete Entity Reference
+
+When the pool controller connects, it creates the following entities in Home Assistant:
+
+### 📊 Primary Sensors
+
+These appear on the device's front page (no `entity_category`):
+
+| Entity ID | Name | Device Class | Unit |
+|-----------|------|-------------|------|
+| `sensor.pool_controller_pool_temp` | Pool Temperature | `temperature` | °C |
+| `sensor.pool_controller_solar_temp` | Solar Temperature | `temperature` | °C |
+
+### 🛠️ Controls (Switches & Select)
+
+| Entity ID | Name | Type | Notes |
+|-----------|------|------|-------|
+| `switch.pool_controller_pool_pump` | Pool Pump | Switch | Writable only in **Manual** mode |
+| `switch.pool_controller_solar_pump` | Solar Pump | Switch | Writable only in **Manual** mode |
+| `select.pool_controller_mode` | Operation Mode | Select | Options: auto, manu, boost, timer |
+
+### 🔧 Configuration Parameters (`entity_category: config`)
+
+| Entity ID | Name | Type | Unit | Range |
+|-----------|------|------|------|-------|
+| `number.pool_controller_pool_max_temp` | Max. Pool Temp | Number | °C | 0–40 |
+| `number.pool_controller_solar_min_temp` | Min. Solar Temp | Number | °C | 0–100 |
+| `number.pool_controller_hysteresis` | Temperature Hysteresis | Number | K | 0–10 |
+| `number.pool_controller_temp_circ_threshold` | Circ. Temp Threshold | Number | °C | 0–40 |
+| `number.pool_controller_temp_circ_factor` | Circ. Temp Factor | Number | min/°C | 0–120 |
+| `number.pool_controller_temp_circ_max_runtime` | Circ. Max Runtime | Number | min | 60–1440 |
+| `time.pool_controller_timer_start` | Timer Start | Time | — | HH:MM:SS |
+| `time.pool_controller_timer_end` | Timer End | Time | — | HH:MM:SS |
+| `select.pool_controller_timezone` | Timezone | Select | — | (dynamic list) |
+| `text.pool_controller_ntp_server` | NTP Server | Text | — | — |
+| `number.pool_controller_firmware_update` | Firmware | Update | — | — |
+| `climate.pool_controller_thermostat` | Pool Thermostat | Climate | °C | 0–40 |
+
+The **Climate** entity (`climate.pool_controller_thermostat`) provides a thermostat-style control:
+- **HVAC modes**: off, auto, heat
+- **Current temperature**: pool water temperature
+- **Target temperature**: maps to Max. Pool Temp
+- **Action**: heating, idle, off
+
+### 🔍 Diagnostics (`entity_category: diagnostic`)
+
+| Entity ID | Name | Device Class | Unit |
+|-----------|------|-------------|------|
+| `sensor.pool_controller_controller_temp` | Controller Temperature | `temperature` | °C |
+| `sensor.pool_controller_heap` | Free Heap Space | — | B |
+| `sensor.pool_controller_max_alloc` | Max Alloc Block | — | B |
+| `sensor.pool_controller_rssi` | WiFi Signal Strength | — | dBm |
+| `sensor.pool_controller_uptime` | System Uptime | `duration` | s |
+| `sensor.pool_controller_local_time` | Local Time | — | — |
+| `sensor.pool_controller_effective_runtime` | Effective Runtime | `duration` | s |
+| `sensor.pool_controller_solar_sensor_found` | Solar Sensor Found | — | Found/Missing |
+| `sensor.pool_controller_pool_sensor_found` | Pool Sensor Found | — | Found/Missing |
+
+### 🧭 Sensor Mapping (Configuration)
+
+| Entity ID | Name | Type | Purpose |
+|-----------|------|------|---------|
+| `select.pool_controller_solar_sensor` | Solar Sensor | Select | Assign a specific DS18B20 as solar sensor |
+| `select.pool_controller_pool_sensor` | Pool Sensor | Select | Assign a specific DS18B20 as pool sensor |
+
+These select entities list all detected DS18B20 addresses on the OneWire bus. Use them to pin a specific sensor to the solar or pool role when multiple sensors are connected.
+
+> **Tip**: After selecting a sensor, check `sensor.pool_controller_solar_sensor_found` and `sensor.pool_controller_pool_sensor_found` to confirm the sensor is detected.
+
+---
+
+## Creating a Dashboard (Lovelace)
+
+### Option A: Add Device Automatically
+
+1. Go to **Settings → Devices & Services → Devices**
+2. Find **Pool Controller** in the device list
+3. Click **Add to Lovelace** on each entity you want to display
+
+### Option B: Manual Lovelace Configuration
+
+Create a view in your `ui-lovelace.yaml` or via the Lovelace UI editor:
+
+```yaml
+type: vertical-stack
+cards:
+  - type: entities
+    title: Pool Controller
+    entities:
+      - entity: sensor.pool_controller_pool_temp
+      - entity: sensor.pool_controller_solar_temp
+      - entity: select.pool_controller_mode
+      - entity: switch.pool_controller_pool_pump
+      - entity: switch.pool_controller_solar_pump
+      - entity: sensor.pool_controller_uptime
+
+  - type: entities
+    title: Configuration
+    entities:
+      - entity: number.pool_controller_pool_max_temp
+      - entity: number.pool_controller_solar_min_temp
+      - entity: number.pool_controller_hysteresis
+      - entity: time.pool_controller_timer_start
+      - entity: time.pool_controller_timer_end
+
+  - type: thermostat
+    entity: climate.pool_controller_thermostat
+
+  - type: entities
+    title: Diagnostics
+    state_color: true
+    entities:
+      - entity: sensor.pool_controller_rssi
+      - entity: sensor.pool_controller_controller_temp
+      - entity: sensor.pool_controller_effective_runtime
+      - entity: sensor.pool_controller_solar_sensor_found
+      - entity: sensor.pool_controller_pool_sensor_found
+```
+
+### Option C: Use the Default Dashboard
+
+The controller creates entities in the default **MQTT device** group. Open **Overview** → click the three dots → **Edit dashboard** → **Add card** → search for "Pool Controller" to add entities individually.
+
+---
+
+## Automation Examples
+
+### Notify When Pool Reaches Target Temperature
+
+```yaml
+alias: "Pool Temperature Alert"
+triggers:
+  - trigger: numeric_state
+    entity_id: sensor.pool_controller_pool_temp
+    above: 28
+actions:
+  - action: notify.mobile_app
+    data:
+      title: "Pool is warm! 🏊"
+      message: "Pool temperature is {{ states('sensor.pool_controller_pool_temp') }}°C"
+```
+
+### Turn Off Heating at Night
+
+```yaml
+alias: "Pool Heating Night Off"
+triggers:
+  - trigger: time
+    at: "22:00:00"
+conditions:
+  - condition: state
+    entity_id: select.pool_controller_mode
+    state: auto
+actions:
+  - action: select.select_option
+    target:
+      entity_id: select.pool_controller_mode
+    data:
+      option: timer
+```
+
+### Restart Controller if Offline
+
+```yaml
+alias: "Pool Controller Offline Alert"
+triggers:
+  - trigger: state
+    entity_id: sensor.pool_controller_uptime
+    to: unavailable
+    for:
+      minutes: 5
+actions:
+  - action: notify.mobile_app
+    data:
+      title: "⚠️ Pool Controller Offline"
+      message: "Pool controller has been unreachable for 5 minutes"
+```
+
+### Energy-Based Solar Circulation
+
+Using the temperature-based circulation parameters (requires controller v3.3+):
+
+```yaml
+alias: "Solar Circulation - Full"
+triggers:
+  - trigger: time_pattern
+    minutes: "/15"
+conditions:
+  - condition: numeric_state
+    entity_id: sensor.pool_controller_solar_temp
+    above: 30
+  - condition: numeric_state
+    entity_id: number.pool_controller_pool_max_temp
+    below: "{{ states('sensor.pool_controller_pool_temp') | float }}"
+actions:
+  - action: switch.turn_on
+    target:
+      entity_id: switch.pool_controller_solar_pump
+```
+
+---
+
+## Firmware Updates via HA
+
+The pool controller exposes an **Update** entity (`update.pool_controller_firmware`) in Home Assistant:
+
+1. Go to **Settings → Devices & Services → Devices → Pool Controller**
+2. The **Firmware** entity shows the current vs. latest version
+3. Click **Install** to trigger an OTA update
+4. The controller downloads the update and reboots automatically
+
+> **Note**: Firmware updates require an internet connection on the ESP32 and at least 2MB of free flash space.
+
+---
+
+## Troubleshooting
+
+### Pool Controller device doesn't appear in Home Assistant
+
+1. **Check MQTT broker connection**: Does the controller show as connected on the MQTT broker? (Check `homeassistant/sensor/pool-controller/availability` topic — payload should be `online`)
+2. **Verify MQTT integration**: Go to **Settings → Devices & Services → Integrations → MQTT** and confirm it's configured
+3. **Check MQTT Discovery is enabled**: In `configuration.yaml`:
+   ```yaml
+   mqtt:
+     discovery: true
+   ```
+4. **Restart MQTT** in Home Assistant: Go to **Settings → System → Restart Services**
+5. **Reboot the controller**: Power-cycle the ESP32 or use the web interface's reboot button
+
+### Entities show as "Unavailable"
+
+- The controller may be offline. Check the `availability` topic mentioned above
+- Messages might be retained from a previous instance. Publish an empty payload to the entity's `/config` topic to clear stale discovery
+- Check `homeassistant/sensor/pool-controller/availability` — it should carry a retained `online` message
+
+### Pump switches don't toggle
+
+The pool controller **only accepts pump commands in Manual mode**. If the controller is in Auto, Boost, or Timer mode, pump commands from Home Assistant are ignored.
+
+To toggle pumps:
+1. Set **Operation Mode** select to `manu` (Manual)
+2. Now the switch entities are writable
+3. After manual control, switch back to `auto` or another mode to resume automated operation
+
+### Numbers don't update when changed
+
+- The controller accepts configuration changes (temperature limits, hysteresis, etc.) **in any mode**
+- Changes are persisted to the controller's flash memory
+- If values revert, check the controller's web interface: **Status → Last Error**
+
+### Sensor mapping switches don't show options
+
+The `select.pool_controller_solar_sensor` and `select.pool_controller_pool_sensor` entities only populate after the controller has completed its OneWire bus scan. This happens:
+- On startup (after WiFi connects)
+- When you press **Rescan** from the web interface
+
+If no DS18B20 sensors are connected, these entities will only show the `— Not configured —` option.


### PR DESCRIPTION
## Summary

Adds the **Home Assistant Integration Guide** — a comprehensive documentation page covering the pool controller v3.x integration with Home Assistant via native MQTT Discovery.

## Changes

### New files
- `content/docs/home-assistant-integration/_index.md` — EN guide
- `content/docs/home-assistant-integration/_index.de.md` — DE guide

### Modified files
- `content/docs/_index.md` / `_index.de.md` — Added 'Home Assistant Integration' entry
- `content/docs/getting-started/_index.md` / `_index.de.md` — Enhanced Step 4, added HA to module overview and 'What's Next' section

## What the guide covers
1. **How MQTT Discovery works** — automatic entity registration
2. **Complete entity reference** — all ~30 entities with tables (sensors, switches, select, numbers, time, text, update, climate, diagnostics, sensor mapping)
3. **Dashboard (Lovelace)** — three setup options with YAML examples
4. **Automation examples** — temperature alerts, night heating off, offline detection
5. **Firmware updates via HA** — OTA update entity
6. **Sensor mapping** — assigning DS18B20 sensors to solar/pool roles
7. **Troubleshooting** — 6 common HA-specific issues with solutions

This is the companion page to PR #13 (openHAB Integration Guide). Together they complete Phase 2 of the documentation rework.