### PR TITLE
docs: add Firmware Migration Guide (v2.x Homie → v3.x HA Discovery)

### DIFF
--- a/content/docs/firmware-migration/_index.de.md
+++ b/content/docs/firmware-migration/_index.de.md
@@ -1,0 +1,193 @@
+---
+title: Firmware-Migration (v2.x → v3.x)
+weight: 50
+tags: ["docs", "migration", "homie", "firmware"]
+---
+
+**🏊 Smart Swimming Pool: Migration vom alten Homie 3.0-Format zum neuen MQTT-Discovery-Format**
+
+Wenn Sie den **Pool Controller v2.x** (oder älter) betreiben und auf **v3.x** upgraden möchten, erklärt dieser Leitfaden, was sich ändert und wie Sie Ihre Smart-Home-Integration aktualisieren müssen.
+
+> 💡 **Neuling?** Wenn Sie den Pool Controller zum ersten Mal installieren, folgen Sie stattdessen der [Erste Schritte](/docs/getting-started/)-Anleitung. Diese Anleitung ist nur relevant, wenn Sie bereits ein Homie 3.0-Setup haben.
+
+---
+
+## Übersicht
+
+| Aspekt | v2.x (Homie 3.0) | v3.x (HA Discovery) |
+|--------|------------------|---------------------|
+| **MQTT-Topic-Format** | `homie/<mac>/<node>/<property>` | `homeassistant/<component>/pool-controller/<id>/state` |
+| **Geräte-ID** | MAC-Adresse (z.B. `5ccf7fb97572`) | `pool-controller` (konfigurierbar) |
+| **Verfügbarkeit** | `homie/<mac>/$state` (`ready`/`lost`) | `homeassistant/sensor/pool-controller/availability` (`online`/`offline`) |
+| **Home Assistant** | Eingeschränkt, manuelle Konfiguration | **Nativ** — automatische Erkennung via MQTT |
+| **openHAB** | Volle Unterstützung (native Konfiguration) | Manuelle MQTT-Konfiguration erforderlich |
+
+---
+
+## Warum die Änderung?
+
+Der Wechsel von Homie 3.0 zu [Home Assistant MQTT Discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery) hatte zwei Ziele:
+
+1. **Null-Konfiguration für Home Assistant-Nutzer** — HA erkennt alle Entitäten automatisch, keine manuelle Konfiguration nötig
+2. **Standardisierung** — HA Discovery ist der De-facto-Standard für MQTT-basierte IoT-Geräte, während Homie 3.0 nie breite Akzeptanz fand
+
+openHAB wird weiterhin vollständig über manuelle MQTT-Konfiguration unterstützt.
+
+---
+
+## Firmware-Upgrade
+
+### Schritt 1: v3.x flashen
+
+Folgen Sie der Standard-Flash-Prozedur in der [Erste Schritte](/docs/getting-started/#firmware-installation)-Anleitung:
+
+```bash
+# In VS Code mit PlatformIO:
+# 1. Firmware hochladen
+# 2. Dateisystem-Image (LittleFS/Webinterface) hochladen
+```
+
+> ⚠️ **Wichtig**: Nach dem Flashen von v3.x ist das Webinterface **komplett neu geschrieben**. Einstellungen aus dem alten Web-UI werden **nicht übernommen**. Sie müssen WiFi und MQTT über den Setup-AP (`Pool-Controller-Setup`) neu konfigurieren.
+
+### Schritt 2: WiFi und MQTT neu konfigurieren
+
+1. Nach dem Flashen startet der ESP32 im AP-Modus (`Pool-Controller-Setup`)
+2. Verbinden Sie sich damit und konfigurieren Sie Ihr WLAN unter `http://192.168.4.1`
+3. Nach dem Neustart konfigurieren Sie MQTT über **Konfiguration → MQTT**
+
+### Schritt 3: Konfigurationsparameter erneut einstellen
+
+Nach der Migration konfigurieren Sie diese Parameter im Webinterface (oder über Home Assistant) neu:
+
+- Maximale Pooltemperatur
+- Minimale Solartemperatur
+- Hysterese
+- Timer Start / Ende
+- Sensor-Adressen (DS18B20)
+
+---
+
+## Migration nach Smart-Home-Plattform
+
+### Home Assistant-Nutzer
+
+**Sie sind nach Schritt 2 fertig.** Die v3.x-Firmware erkennt sich automatisch über MQTT Discovery.
+
+1. Gehen Sie zu **Einstellungen → Geräte & Dienste**
+2. Das Gerät **Pool Controller** sollte automatisch erscheinen
+3. Siehe [Home Assistant Integrations-Guide](/docs/home-assistant-integration/) für die vollständige Entity-Referenz
+
+> **Hinweis**: Wenn Sie manuell MQTT-Sensoren in Home Assistant für die Homie-Topics konfiguriert hatten, werden diese nach dem Upgrade als **nicht verfügbar** angezeigt. Entfernen Sie sie manuell — die automatisch erkannten Entitäten ersetzen sie.
+
+### openHAB-Nutzer
+
+openHAB erfordert **manuelle MQTT-Konfiguration**. Der [openHAB Integrations-Guide](/docs/openhab-integration/) zeigt die vollständige Einrichtung.
+
+#### Was sich ändern muss
+
+| Datei | Änderung |
+|-------|----------|
+| `things/mqtt.things` | Alle Topic-Pfade: `homie/<mac>/...` → `homeassistant/...` |
+| `items/2-pool.items` | Channel-Bindungen: Topic-Referenzen aktualisieren |
+| `sitemaps/pool.sitemap` | Meist keine Änderung (Item-Namen bleiben gleich) |
+
+#### Topic-Mapping-Referenz
+
+| v2.x Homie-Topic | v3.x HA-Discovery-Topic |
+|-------------------|------------------------|
+| `homie/<mac>/operation-mode/mode` | `homeassistant/select/pool-controller/mode/state` |
+| `homie/<mac>/operation-mode/mode/set` | `homeassistant/select/pool-controller/mode/set` |
+| `homie/<mac>/operation-mode/pool-max-temp` | `homeassistant/number/pool-controller/pool-max-temp/state` |
+| `homie/<mac>/operation-mode/pool-max-temp/set` | `homeassistant/number/pool-controller/pool-max-temp/set` |
+| `homie/<mac>/operation-mode/solar-min-temp` | `homeassistant/number/pool-controller/solar-min-temp/state` |
+| `homie/<mac>/operation-mode/solar-min-temp/set` | `homeassistant/number/pool-controller/solar-min-temp/set` |
+| `homie/<mac>/operation-mode/hysteresis` | `homeassistant/number/pool-controller/hysteresis/state` |
+| `homie/<mac>/operation-mode/hysteresis/set` | `homeassistant/number/pool-controller/hysteresis/set` |
+| `homie/<mac>/pool-pump/switch` | `homeassistant/switch/pool-controller/pool-pump/state` |
+| `homie/<mac>/pool-pump/switch/set` | `homeassistant/switch/pool-controller/pool-pump/set` |
+| `homie/<mac>/solar-pump/switch` | `homeassistant/switch/pool-controller/solar-pump/state` |
+| `homie/<mac>/solar-pump/switch/set` | `homeassistant/switch/pool-controller/solar-pump/set` |
+| `homie/<mac>/pool-temp/temperature` | `homeassistant/sensor/pool-controller/pool-temp/state` |
+| `homie/<mac>/solar-temp/temperature` | `homeassistant/sensor/pool-controller/solar-temp/state` |
+
+#### Wichtige Werte-Änderungen
+
+| Aspekt | v2.x (Homie) | v3.x (HA Discovery) |
+|--------|-------------|---------------------|
+| Pumpe EIN | `true` | `ON` |
+| Pumpe AUS | `false` | `OFF` |
+| Verfügbarkeit online | `ready` | `online` |
+| Verfügbarkeit offline | `lost` | `offline` |
+
+---
+
+## Breaking Changes
+
+### 1. Timer-Entities umstrukturiert
+
+**v2.x**: 4 separate `number`-Entities für Timer-Start/Ende (Stunden + Minuten einzeln)
+
+```
+homie/<mac>/operation-mode/timer-start-h
+homie/<mac>/operation-mode/timer-start-min
+homie/<mac>/operation-mode/timer-end-h
+homie/<mac>/operation-mode/timer-end-min
+```
+
+**v3.x**: 2 `time`-Entities im `HH:MM:SS`-Format
+
+```
+homeassistant/time/pool-controller/timer-start
+homeassistant/time/pool-controller/timer-end
+```
+
+Die alten Entitäten werden automatisch aus Home Assistant entfernt, wenn v3.x startet (leere retained-Payloads werden auf ihre Config-Topics veröffentlicht).
+
+### 2. Timezone-Entity geändert
+
+**v2.x**: `number`-Entity mit Zeitzonen-Index (z.B. `0`, `1`, ...)
+
+**v3.x**: `select`-Entity mit lesbaren Zeitzonen-Labels (z.B. `Europe/Berlin`, `America/New_York`)
+
+### 3. Temperaturbasierte Zirkulation (neu in v3.3+)
+
+v3.3 fügte drei neue Konfigurationsparameter für temperaturgesteuerte Zirkulation hinzu:
+
+- `temp-circ-threshold` — minimale Temperaturdifferenz für Zirkulation
+- `temp-circ-factor` — Laufzeit-Multiplikator pro Grad über Schwelle
+- `temp-circ-max-runtime` — maximale Zirkulationslaufzeit
+
+Diese gab es in v2.x nicht und haben kein Homie-Äquivalent.
+
+### 4. Geräte-ID ist jetzt konfigurierbar
+
+In v2.x war die Geräte-ID **immer** die MAC-Adresse (`5ccf7fb97572`). In v3.x ist die Standard-ID `pool-controller`, aber Sie können sie im Webinterface unter **Konfiguration → MQTT → Geräte-ID** **ändern**.
+
+Wenn Sie sie ändern, aktualisieren Sie alle Topic-Pfade entsprechend.
+
+### 5. Kein Homie-Kompatibilitätsmodus
+
+Die v3.x-Firmware **unterstützt nur** Home Assistant MQTT Discovery. Es gibt keinen Rückwärtskompatibilitätsmodus für Homie 3.0. Wenn Sie Homie für benutzerdefinierte Integrationen benötigen, bleiben Sie bei v2.x.
+
+---
+
+## Rollback
+
+Falls Sie zu v2.x zurückkehren müssen:
+
+1. Flashen Sie die v2.x-Firmware mit PlatformIO
+2. Konfigurieren Sie WiFi und MQTT neu (v2.x verwendet ebenfalls den Setup-AP)
+3. Die alten Homie-Topics werden wieder aktiv
+4. openHAB oder Home Assistant verbinden sich automatisch neu
+
+> **Hinweis**: Das Flashen von v3.x löscht die LittleFS-Dateisystempartition. v2.x speichert die Konfiguration möglicherweise anders. Planen Sie ein, nach dem Downgrade alle Einstellungen neu zu konfigurieren.
+
+---
+
+## Ältere Firmware-Versionen
+
+| Version | MQTT-Format | Status |
+|---------|-------------|--------|
+| **1.x** | Proprietäres JSON | Nicht mehr unterstützt |
+| **2.x** | Homie 3.0 | Legacy — Update empfohlen |
+| **3.x** | HA Discovery | Aktuell — für alle Nutzer empfohlen |

--- a/content/docs/firmware-migration/_index.md
+++ b/content/docs/firmware-migration/_index.md
@@ -1,0 +1,193 @@
+---
+title: Firmware Migration (v2.x → v3.x)
+weight: 50
+tags: ["docs", "migration", "homie", "firmware"]
+---
+
+**🏊 Smart Swimming Pool: Migrate from the old Homie 3.0 format to the new MQTT Discovery format**
+
+If you are running the **Pool Controller v2.x** (or earlier) and plan to upgrade to **v3.x**, this guide explains what changes and how to update your smart home integration.
+
+> 💡 **New user?** If you are installing the pool controller for the first time, follow the [Getting Started](/docs/getting-started/) guide instead. This guide is only relevant if you have an existing Homie 3.0 setup.
+
+---
+
+## Overview
+
+| Aspect | v2.x (Homie 3.0) | v3.x (HA Discovery) |
+|--------|------------------|---------------------|
+| **MQTT topic format** | `homie/<mac>/<node>/<property>` | `homeassistant/<component>/pool-controller/<id>/state` |
+| **Device identifier** | MAC address (e.g., `5ccf7fb97572`) | `pool-controller` (configurable) |
+| **Availability** | `homie/<mac>/$state` (`ready`/`lost`) | `homeassistant/sensor/pool-controller/availability` (`online`/`offline`) |
+| **Home Assistant** | Limited support, manual config | **Native** — auto-discovery via MQTT |
+| **openHAB** | Full support (native configuration) | Manual MQTT configuration required |
+
+---
+
+## Why the Change?
+
+The switch from Homie 3.0 to [Home Assistant MQTT Discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery) was driven by two goals:
+
+1. **Zero-config for Home Assistant users** — HA auto-discovers all entities, no manual configuration needed
+2. **Standardization** — HA Discovery is the de-facto standard for MQTT-based IoT devices, while Homie 3.0 never gained broad adoption
+
+openHAB remains fully supported via manual MQTT configuration.
+
+---
+
+## Firmware Upgrade
+
+### Step 1: Flash v3.x
+
+Follow the standard flashing procedure in the [Getting Started](/docs/getting-started/#firmware-installation) guide:
+
+```bash
+# In VS Code with PlatformIO:
+# 1. Upload the firmware
+# 2. Upload the filesystem image (LittleFS/web interface)
+```
+
+> ⚠️ **Important**: After flashing v3.x, the web interface is **fully rewritten**. Settings from the old web UI are **not** carried over. You must reconfigure WiFi and MQTT via the setup AP (`Pool-Controller-Setup`).
+
+### Step 2: Reconfigure WiFi and MQTT
+
+1. After flashing, the ESP32 starts in AP mode (`Pool-Controller-Setup`)
+2. Connect to it and configure your WiFi at `http://192.168.4.1`
+3. After reboot, configure MQTT via **Configuration → MQTT**
+
+### Step 3: Reapply Configuration Parameters
+
+After migration, reconfigure these parameters in the web interface (or via Home Assistant):
+
+- Max. Pool Temperature
+- Min. Solar Temperature
+- Hysteresis
+- Timer Start / End
+- Sensor addresses (DS18B20)
+
+---
+
+## Migration by Smart Home Platform
+
+### Home Assistant Users
+
+**You're done after Step 2.** The v3.x firmware auto-discovers via MQTT.
+
+1. Go to **Settings → Devices & Services**
+2. The **Pool Controller** device should appear automatically
+3. See the [Home Assistant Integration Guide](/docs/home-assistant-integration/) for the complete entity reference
+
+> **Note**: If you had manually configured MQTT sensors in Home Assistant for the Homie topics, those will show as **unavailable** after the upgrade. Remove them manually — the auto-discovered entities replace them.
+
+### openHAB Users
+
+openHAB requires **manual MQTT configuration**. The [openHAB Integration Guide](/docs/openhab-integration/) shows the complete setup.
+
+#### What needs to change
+
+| File | Change |
+|------|--------|
+| `things/mqtt.things` | All topic paths: `homie/<mac>/...` → `homeassistant/...` |
+| `items/2-pool.items` | Channel bindings: update topic references |
+| `sitemaps/pool.sitemap` | Usually no change (item names stay the same) |
+
+#### Topic mapping reference
+
+| v2.x Homie Topic | v3.x HA Discovery Topic |
+|-------------------|------------------------|
+| `homie/<mac>/operation-mode/mode` | `homeassistant/select/pool-controller/mode/state` |
+| `homie/<mac>/operation-mode/mode/set` | `homeassistant/select/pool-controller/mode/set` |
+| `homie/<mac>/operation-mode/pool-max-temp` | `homeassistant/number/pool-controller/pool-max-temp/state` |
+| `homie/<mac>/operation-mode/pool-max-temp/set` | `homeassistant/number/pool-controller/pool-max-temp/set` |
+| `homie/<mac>/operation-mode/solar-min-temp` | `homeassistant/number/pool-controller/solar-min-temp/state` |
+| `homie/<mac>/operation-mode/solar-min-temp/set` | `homeassistant/number/pool-controller/solar-min-temp/set` |
+| `homie/<mac>/operation-mode/hysteresis` | `homeassistant/number/pool-controller/hysteresis/state` |
+| `homie/<mac>/operation-mode/hysteresis/set` | `homeassistant/number/pool-controller/hysteresis/set` |
+| `homie/<mac>/pool-pump/switch` | `homeassistant/switch/pool-controller/pool-pump/state` |
+| `homie/<mac>/pool-pump/switch/set` | `homeassistant/switch/pool-controller/pool-pump/set` |
+| `homie/<mac>/solar-pump/switch` | `homeassistant/switch/pool-controller/solar-pump/state` |
+| `homie/<mac>/solar-pump/switch/set` | `homeassistant/switch/pool-controller/solar-pump/set` |
+| `homie/<mac>/pool-temp/temperature` | `homeassistant/sensor/pool-controller/pool-temp/state` |
+| `homie/<mac>/solar-temp/temperature` | `homeassistant/sensor/pool-controller/solar-temp/state` |
+
+#### Key changes in values
+
+| Aspect | v2.x (Homie) | v3.x (HA Discovery) |
+|--------|-------------|---------------------|
+| Pump ON value | `true` | `ON` |
+| Pump OFF value | `false` | `OFF` |
+| Availability online | `ready` | `online` |
+| Availability offline | `lost` | `offline` |
+
+---
+
+## Breaking Changes
+
+### 1. Timer entities restructured
+
+**v2.x**: 4 separate `number` entities for timer start/end (hours + minutes each)
+
+```
+homie/<mac>/operation-mode/timer-start-h
+homie/<mac>/operation-mode/timer-start-min
+homie/<mac>/operation-mode/timer-end-h
+homie/<mac>/operation-mode/timer-end-min
+```
+
+**v3.x**: 2 `time` entities with `HH:MM:SS` format
+
+```
+homeassistant/time/pool-controller/timer-start
+homeassistant/time/pool-controller/timer-end
+```
+
+The old entities are automatically removed from Home Assistant when v3.x starts (empty retained payloads are published to their config topics).
+
+### 2. Timezone entity changed
+
+**v2.x**: `number` entity with timezone index (e.g., `0`, `1`, ...)
+
+**v3.x**: `select` entity with human-readable timezone labels (e.g., `Europe/Berlin`, `America/New_York`)
+
+### 3. Temperature-based circulation (new in v3.3+)
+
+v3.3 added three new configuration parameters for temperature-controlled circulation:
+
+- `temp-circ-threshold` — minimum temperature difference to trigger circulation
+- `temp-circ-factor` — runtime multiplier per degree above threshold
+- `temp-circ-max-runtime` — maximum circulation runtime
+
+These did not exist in v2.x and have no Homie equivalent.
+
+### 4. Device identifier is now configurable
+
+In v2.x, the device ID was **always** the MAC address (`5ccf7fb97572`). In v3.x, the default device ID is `pool-controller`, but you can **change it** in **Configuration → MQTT → Device ID** in the web interface.
+
+If you change it, update all topic paths accordingly.
+
+### 5. No Homie-compatibility mode
+
+The v3.x firmware **only** supports Home Assistant MQTT Discovery. There is no Homie 3.0 backward-compatibility mode. If you need Homie for custom integrations, stay on v2.x.
+
+---
+
+## Rollback
+
+If you need to revert to v2.x:
+
+1. Flash the v2.x firmware using PlatformIO
+2. Reconfigure WiFi and MQTT (v2.x also uses the setup AP)
+3. The old Homie topics become active again
+4. openHAB or Home Assistant will reconnect automatically
+
+> **Note**: The v3.x flash erases the LittleFS filesystem partition. v2.x may store configuration differently. Expect to reconfigure all settings after downgrading.
+
+---
+
+## Older Firmware Versions
+
+| Version | MQTT Format | Status |
+|---------|-------------|--------|
+| **1.x** | Proprietary JSON | No longer supported |
+| **2.x** | Homie 3.0 | Legacy — update recommended |
+| **3.x** | HA Discovery | Current — recommended for all users |


### PR DESCRIPTION
## Summary

Adds the **Firmware Migration Guide** — a dedicated page for users upgrading from Pool Controller v2.x (Homie 3.0 MQTT) to v3.x (Home Assistant MQTT Discovery).

This is **Phase 3** of the documentation rework (after openHAB Integration Guide + Home Assistant Integration Guide).

## New files
- `content/docs/firmware-migration/_index.md` — EN guide
- `content/docs/firmware-migration/_index.de.md` — DE guide

## What the guide covers
1. **Overview table** — Homie 3.0 vs HA Discovery comparison
2. **Firmware upgrade steps** — flash, reconfigure, reapply settings
3. **Platform-specific migration** — HA users (auto-discovery) vs openHAB users (manual topic update)
4. **Topic mapping reference** — 14-row before/after table
5. **Value changes** — true/false → ON/OFF, ready/lost → online/offline
6. **Breaking changes** — timer restructure (4 number → 2 time), timezone (number → select), new temperature-based circulation params
7. **Rollback instructions**
8. **Version overview** — v1.x proprietary JSON, v2.x Homie 3.0, v3.x HA Discovery

## Notes
- The [openHAB Integration Guide](/docs/openhab-integration/) and [Home Assistant Integration Guide](/docs/home-assistant-integration/) are cross-linked from the migration page
- Setting up the stub pages (no existing content yet) — they are referenced from this guide