### PR TITLE
docs: add complete bill of materials (#18)

### DIFF
--- a/content/docs/_index.de.md
+++ b/content/docs/_index.de.md
@@ -9,6 +9,8 @@ weight: 1
 
 Dieses Projekt ist in verschiedene Module aufgeteilt:
 
+- **[Stückliste (BOM)](/docs/bom/)**:
+  Vollständige Einkaufsliste mit Teilenummern, Preisen und Bezugstipps.
 - **[Pool Controller](/docs/pool-controller/)**:
   Das Herz der Steuerung — zentrale Steuerlogik auf ESP32-Basis.
 - **[Home Assistant Integration](/docs/home-assistant-integration/)**:

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -9,6 +9,8 @@ weight: 1
 
 This project is split into several modules:
 
+- **[Bill of Materials](/docs/bom/)**:
+  Complete shopping list with part numbers, prices, and sourcing tips.
 - **[Pool Controller](/docs/pool-controller/)**:
   The heart of the 🏊 Smart Swimming Pool — ESP32-based central control logic.
 - **[Home Assistant Integration](/docs/home-assistant-integration/)**:

--- a/content/docs/bom/_index.de.md
+++ b/content/docs/bom/_index.de.md
@@ -1,0 +1,154 @@
+---
+title: Stückliste (BOM)
+weight: 9
+tags: ["docs", "bom", "hardware", "shopping-list"]
+---
+
+**🏊 Smart Swimming Pool: Vollständige Einkaufsliste mit Teilenummern, Preisen und Bezugstipps.**
+
+Diese Stückliste (Bill of Materials / BOM) deckt alle Komponenten ab, die für den Bau des Pool-Controllers benötigt werden — inklusive Elektrik, Sensorik, Gehäuse und Werkzeug. Preisangaben sind Schätzwerte Stand 2026.
+
+---
+
+## 1. Controller-Elektronik
+
+Diese Teile bilden den Kern des Pool-Controllers. Alle Komponenten sind Standard-Maker/Hobbyist-Artikel.
+
+| # | Bauteil | Menge | Ca. Preis | Details | Beispiel-Quelle |
+|---|---------|:-----:|:---------:|---------|-----------------|
+| 1 | **ESP32 DevKit V1** (CP2102) | 1 | 10–15 € | 4MB Flash, CP2102 USB-Serial | Amazon, AZ-Delivery |
+| 2 | **2-Kanal 5V Relais-Modul** | 1 | 5–8 € | Aktiv-Low, Optokopler-isoliert, HW-279/HW-316 | Amazon, eBay |
+| 3 | **DS18B20 Temperatursensor** (wasserdicht) | 2 | 4–6 €/Stk | Edelstahlsonde, 1m Kabel, 3-adrig | Amazon, Reichelt |
+| 4 | **4,7kΩ Widerstand** (¼W, ±5%) | 2 | 0,10 €/Stk | Metallschicht oder Kohleschicht | Reichelt, Pollin |
+| 5 | **Breadboard** (830 Kontakte) | 1 | 3–5 € | Für Prototyping | Amazon, Reichelt |
+| 6 | **Jumper-Kabel** (M-M, M-F) | 20+ | 3–5 € | Verschiedene Farben/Längen | Amazon |
+| 7 | **USB-Netzteil** (5V, 1A+) | 1 | 5–10 € | Qualitätsmarke (Anker, Samsung, Apple) | Fachhandel |
+| 8 | **USB-A auf Micro-USB Kabel** | 1 | 3–5 € | **Datenkabel** (kein reines Ladekabel) | Amazon |
+
+| | **Zwischensumme (nur Controller)** | | **~35–55 €** | |
+| | (Bestehende BOM = 45–75 € inkl. Gehäuse) | | | |
+
+---
+
+## 2. Gehäuse & Mechanik
+
+Schützt die Elektronik vor Feuchtigkeit und mechanischen Beschädigungen.
+
+| # | Bauteil | Menge | Ca. Preis | Details | Beispiel-Quelle |
+|---|---------|:-----:|:---------:|---------|-----------------|
+| 9 | **Hutschienengehäuse** (ABS, IP54+) | 1 | 8–15 € | Z.B. Fibox 4-Module, 100×75×105mm | Reichelt, Conrad |
+| 10 | **Hutschiene** (35mm, 15cm) | 1 | 2–4 € | Gelochte Stahlschiene zur Montage | Reichelt |
+| 11 | **PG7 Kabelverschraubung** (5–7mm Kabel) | 4–6 | 1–2 €/Stk | Für Sensorkabel und USB-Eingang | Amazon, Reichelt |
+| 12 | **PG11 Kabelverschraubung** (8–10mm Kabel) | 1–2 | 1–2 €/Stk | Für Netzkabel-Eingang (falls 230V im Gehäuse) | Amazon, Reichelt |
+| 13 | **Hutschienen-Halter** für ESP32 | 1 | 3–5 € | 3D-gedruckt optional; Kabelbinder gehen auch | Thingiverse |
+| 14 | **Kabelbinder** (100mm, Sortiment) | 10+ | 2–3 € | Kabelmanagement im Gehäuse | Baumarkt |
+| 15 | **Kabelbinder-Grundplatten** (klebend) | 5+ | 3–4 € | Auf Gehäuseinnenfläche kleben | Amazon |
+
+| | **Zwischensumme (Gehäuse)** | | **~25–45 €** | |
+| | *Nicht nötig bei reiner Breadboard-Nutzung im Innenbereich* | | | |
+
+---
+
+## 3. Elektroinstallation (230V)
+
+Für den sicheren Anschluss der Relais an die Pumpen.
+
+| # | Bauteil | Menge | Ca. Preis | Details | Hinweise |
+|---|---------|:-----:|:---------:|---------|----------|
+| 16 | **FI-Schutzschalter (RCD)** (30mA) | 1 | 20–35 € | 2-polig, 25A, 30mA Bemessungsfehlerstrom | **Vorgeschrieben** für 230V |
+| 17 | **Leitungsschutzschalter (MCB)** (B10A oder B16A) | 1–2 | 5–10 €/Stk | Überstromschutz pro Pumpenstromkreis | Pro Pumpenkreis |
+| 18 | **Dreiadriges Netzkabel** (NYM-J 3×1,5mm²) | 5–10m | 2–3 €/m | Für 230V-Verdrahtung zwischen Relais und Pumpen | Baumarkt |
+| 19 | **Flexibles Steuerkabel** (LiYY 3×0,75mm²) | 2–3m | 1–2 €/m | Für Relais→Pumpe-Verbindung im Gehäuse | Reichelt |
+| 20 | **Aderendhülsen** (0,75mm² und 1,5mm²) | 20+ | 3–5 € | Für feindrähtige Leiter an Schraubklemmen | Reichelt, Amazon |
+| 21 | **Aderendhülsen-Crimper** | 1 | 8–15 € | Zum Verpressen der Hülsen | Reichelt, Amazon |
+| 22 | **Hutschienen-Reihenklemmen** (2,5mm², grau) | 4–6 | 1–2 €/Stk | Zur Verdrahtungsverteilung im Gehäuse | Reichelt, Wago |
+| 23 | **Hutschienen-Schutzklemme** (grün-gelb) | 2 | 2–3 €/Stk | Für PE-/Erdungsanschluss | Reichelt |
+| 24 | **Endwinkel** für Reihenklemmen | 2 | 1 €/Stk | Fixieren der Klemmen auf der Hutschiene | Reichelt |
+| 25 | **Aderkennzeichnungsringe** (nummeriert) | 1 Satz | 3–5 € | Zur Kabelfindung bei Wartung | Reichelt |
+| 26 | **Zugentlastung** für Netzkabel | 2 | 2–4 €/Stk | Verhindert Zugbelastung der Klemmen | Baumarkt |
+
+| | **Zwischensumme (Elektrik)** | | **~60–110 €** | |
+| | *Vieles ist ggf. bereits im Verteilerkasten vorhanden* | | | |
+
+---
+
+## 4. Temperatursensor-Montage
+
+Zusätzliches Material zur Montage der DS18B20-Sensoren an Rohren.
+
+| # | Bauteil | Menge | Ca. Preis | Details | Hinweise |
+|---|---------|:-----:|:---------:|---------|----------|
+| 27 | **DS18B20 Edelstahlsonde** (9mm × 30mm) | 2 | 4–6 €/Stk | Bessere Qualität als Generic — nach "Sanitary" suchen | Reichelt, Amazon |
+| 28 | **Sensor-Verlängerungskabel** (4-adrig, geschirmt) | 5–15m | 2–3 €/m | Zur Verlängerung; **geschirmte Twisted-Pair** bevorzugt | Reichelt |
+| 29 | **Schrumpfschlauch** (Sortiment, 3:1) | 1 Satz | 3–5 € | Zum Abdichten von Kabelverbindungen | Amazon |
+| 30 | **Kabelschellen** (für Rohrmontage) | 10+ | 2–3 € | Sensorkabel entlang Rohrleitungen fixieren | Baumarkt |
+| 31 | **Wärmeleitpaste** (CPU-Paste) | 1 Tube | 3–5 € | Verbessert Wärmeübergang zwischen Sonde und Rohr | Reichelt |
+| 32 | **Kabelverbindungsdose** (IP44+) | 1 | 3–5 € | Für Sensor-Verlängerungsverbindungen | Baumarkt |
+
+| | **Zwischensumme (Sensormontage)** | | **~25–45 €** | |
+| | *Stark abhängig von benötigten Kabellängen* | | | |
+
+---
+
+## 5. Werkzeug & Verbrauchsmaterial
+
+Wichtige Werkzeuge für den Zusammenbau — nicht in den Controller-Kosten enthalten.
+
+| # | Werkzeug | Ca. Preis | Erforderlich? | Hinweise |
+|---|----------|:---------:|:-----------:|----------|
+| 33 | **Digital-Multimeter** | 15–30 € | ✅ **Ja** | Muss Gleichspannung, Durchgang, Widerstand messen |
+| 34 | **Abisolierzange** (automatisch) | 8–15 € | ✅ **Ja** | Zum Abisolieren von 0,75–2,5mm² Leitungen |
+| 35 | **Schraubendreher-Satz** (Schlitz + Kreuz) | 5–10 € | ✅ Ja | Für Reihenklemmen und Hutschienen-Komponenten |
+| 36 | **Lötkolben** (30W+) | 15–25 € | ⬜ Optional | Nur bei Sensor-Verlängerungen mit Löten |
+| 37 | **Heißluftföhn** | 15–30 € | ⬜ Optional | Für Schrumpfschlauch |
+| 38 | **Durchgangsprüfer** | 5–10 € | ⬜ Optional | Zur Überprüfung der Verdrahtung |
+
+| | **Zwischensumme (Werkzeug)** | | **~60–100 €** | |
+| | *Teilweise bereits im eigenen Werkstattbestand* | | | |
+
+---
+
+## Bestellreihenfolge
+
+Wenn Sie alles auf einmal bestellen möchten, hier die Priorität:
+
+1. **Must-have (ESP32, Relais, Sensoren, Widerstände, Breadboard, Netzteil)** — ~35 €
+   → Reicht zum Flashen der Firmware und Testen der Sensoren
+2. **Gehäuse + Verschraubungen + Hutschiene** — ~25 €
+   → Für den dauerhaften Einbau
+3. **Elektrik (FI, LS, Kabel, Klemmen)** — ~60 €
+   → Nur falls der Verteilerkasten erweitert werden muss
+4. **Sensor-Montage (Kabel, Schrumpfschlauch)** — ~25 €
+   → Nur bei entfernten Sensor-Standorten
+
+Sie können mit **Must-have-Teilen** (Kategorie 1) starten und später erweitern.
+
+---
+
+## Bezugstipps
+
+| Artikel | Tipp |
+|---------|------|
+| **ESP32** | Bei AZ-Delivery (Deutschland) kaufen — bekannte Qualität, schneller Versand. "ESP32 WROOM" von No-Name-Verkäufern meiden. |
+| **DS18B20** | Nach "DS18B20 sanitary sensor" suchen — bessere Abdichtung. Günstige (<2€) fallen oft nach 1–2 Saisons aus. |
+| **Relais-Modul** | Auf **Optokopler-isoliert** und **Aktiv-Low** achten. HW-279 ist das zuverlässigste Modell. |
+| **FI-Schutzschalter** | Von Hager, ABB, Schneider oder Siemens kaufen. No-Name-Sicherheitsschalter meiden. |
+| **Kabel** | NYM-J für feste Installation, LiYY für flexible Innenverdrahtung. |
+| **Widerstände** | 4,7kΩ, ¼W, ±5% — kosten 10 Cent. 10 Stück kaufen, Reserve haben. |
+
+---
+
+## Preiszusammenfassung
+
+| Kategorie | Hauptkomponenten | Preisrahmen |
+|-----------|-----------------|-------------|
+| Controller-Elektronik | ESP32, Relais, Sensoren, Breadboard, Netzteil | **35–55 €** |
+| Gehäuse & Mechanik | Gehäuse, Verschraubungen, Hutschiene, Befestigung | **25–45 €** |
+| Elektrik (230V) | FI, LS, Kabel, Klemmen, Aderendhülsen | **60–110 €** |
+| Sensor-Montage | Verlängerungskabel, Schrumpfschlauch, Verbindungsdose | **25–45 €** |
+| Werkzeug | Multimeter, Abisolierzange, Schraubendreher | **60–100 €** |
+| **Gesamt (nur Controller)** | Kategorien 1–2 | **60–100 €** |
+| **Gesamt (komplette Installation)** | Kategorien 1–4 | **145–255 €** |
+| **Inkl. Werkzeug** | Kategorien 1–5 | **205–355 €** |
+
+> 💡 Die bestehende "Erste Schritte"-BOM schätzt **45–75 €** für die **Controller-Elektronik + Gehäuse** (Kategorien 1+2). Die erweiterte BOM oben ergänzt die **Elektroinstallation (230V)** und das **Sensor-Montagematerial**, die für eine reale Pool-Installation notwendig sind.

--- a/content/docs/bom/_index.md
+++ b/content/docs/bom/_index.md
@@ -1,0 +1,154 @@
+---
+title: Bill of Materials
+weight: 9
+tags: ["docs", "bom", "hardware", "shopping-list"]
+---
+
+**🏊 Smart Swimming Pool: Complete shopping list with part numbers, prices, and sourcing tips.**
+
+This BOM covers all components needed to build the pool controller including the electronics, electrical installation, sensors, and enclosure. Prices are estimates as of 2026.
+
+---
+
+## 1. Controller Electronics
+
+These parts make up the core pool controller. All items are standard maker/hobbyist components.
+
+| # | Component | Qty | Est. Price | Details | Example Source |
+|---|-----------|:---:|:----------:|---------|----------------|
+| 1 | **ESP32 DevKit V1** (CP2102) | 1 | 10–15 € | 4MB flash, CP2102 USB-serial | Amazon, AZ-Delivery |
+| 2 | **2-Channel 5V Relay Module** | 1 | 5–8 € | Active-low, optocoupler isolated, HW-279/HW-316 | Amazon, eBay |
+| 3 | **DS18B20 temperature sensor** (waterproof) | 2 | 4–6 €/ea | Stainless steel probe, 1m cable, 3-wire | Amazon, Reichelt |
+| 4 | **4.7kΩ resistor** (¼W, ±5%) | 2 | 0.10 €/ea | Metal film or carbon film | Reichelt, Pollin |
+| 5 | **Breadboard** (830 tie points) | 1 | 3–5 € | For prototyping | Amazon, Reichelt |
+| 6 | **Jumper wires** (M-M, M-F) | 20+ | 3–5 € | Assorted colors/lengths | Amazon |
+| 7 | **USB power supply** (5V, 1A+) | 1 | 5–10 € | Quality brand (Anker, Samsung, Apple) | Local electronics store |
+| 8 | **USB-A to Micro-USB cable** | 1 | 3–5 € | **Data cable** (not charge-only) | Amazon |
+
+| | **Subtotal (controller only)** | | **~35–55 €** | |
+| | (Existing BOM = 45–75 € incl. enclosure) | | | |
+
+---
+
+## 2. Enclosure & Mechanics
+
+Protect the electronics from moisture and physical damage.
+
+| # | Component | Qty | Est. Price | Details | Example Source |
+|---|-----------|:---:|:----------:|---------|----------------|
+| 9 | **DIN rail enclosure** (ABS, IP54+) | 1 | 8–15 € | e.g. Fibox 4-module, 100×75×105mm | Reichelt, Conrad |
+| 10 | **DIN rail** (35mm, 15cm) | 1 | 2–4 € | Slotted steel rail for mounting | Reichelt |
+| 11 | **PG7 cable gland** (5–7mm cable) | 4–6 | 1–2 €/ea | For sensor cables and USB entry | Amazon, Reichelt |
+| 12 | **PG11 cable gland** (8–10mm cable) | 1–2 | 1–2 €/ea | For mains cable entry (if 230V in enclosure) | Amazon, Reichelt |
+| 13 | **DIN rail mount adapter** for ESP32 | 1 | 3–5 € | 3D-printed optional; zip ties also work | Thingiverse |
+| 14 | **Zip ties** (100mm, assortment) | 10+ | 2–3 € | Cable management inside enclosure | Any hardware store |
+| 15 | **Adhesive cable tie mounts** | 5+ | 3–4 € | Stick to enclosure interior | Amazon |
+
+| | **Subtotal (enclosure)** | | **~25–45 €** | |
+| | *Not required if breadboard is used indoors* | | | |
+
+---
+
+## 3. Electrical Installation (230V)
+
+For connecting the relay module to the pumps safely.
+
+| # | Component | Qty | Est. Price | Details | Notes |
+|---|-----------|:---:|:----------:|---------|-------|
+| 16 | **RCD / FI circuit breaker** (30mA) | 1 | 20–35 € | 2-pole, 25A, 30mA rated residual current | **Mandatory** for 230V |
+| 17 | **MCB / circuit breaker** (B10A or B16A) | 1–2 | 5–10 €/ea | For pump circuit overcurrent protection | Per pump circuit |
+| 18 | **Three-core mains cable** (NYM-J 3×1.5mm²) | 5–10m | 2–3 €/m | For 230V wiring between relay and pumps | Hardware store |
+| 19 | **Flexible control cable** (LiYY 3×0.75mm²) | 2–3m | 1–2 €/m | For relay → pump connection inside enclosure | Reichelt |
+| 20 | **Wire ferrules** (0.75mm² and 1.5mm²) | 20+ | 3–5 € | For stranded wire termination in screw terminals | Reichelt, Amazon |
+| 21 | **Ferrule crimping tool** | 1 | 8–15 € | For crimping ferrules | Reichelt, Amazon |
+| 22 | **DIN rail terminal blocks** (2.5mm², grey) | 4–6 | 1–2 €/ea | For wiring distribution inside enclosure | Reichelt, Wago |
+| 23 | **DIN rail grounding terminal** (green-yellow) | 2 | 2–3 €/ea | For PE / ground connection | Reichelt |
+| 24 | **End brackets** for terminal blocks | 2 | 1 €/ea | Fix terminal blocks on DIN rail | Reichelt |
+| 25 | **Cable markers** (numbered rings) | 1 set | 3–5 € | For identifying wires during maintenance | Reichelt |
+| 26 | **Strain relief** for mains cable | 2 | 2–4 €/ea | Prevent cable pull from reaching terminals | Hardware store |
+
+| | **Subtotal (electrical)** | | **~60–110 €** | |
+| | *Many items may already be in your distribution panel* | | | |
+
+---
+
+## 4. Temperature Sensor Installation
+
+Additional materials for mounting DS18B20 sensors on pipes.
+
+| # | Component | Qty | Est. Price | Details | Notes |
+|---|-----------|:---:|:----------:|---------|-------|
+| 27 | **DS18B20 stainless steel probe** (9mm × 30mm) | 2 | 4–6 €/ea | Better quality than generic — look for "Sanitary" variant | Reichelt, Amazon |
+| 28 | **Sensor cable** (4-conductor, shielded, 2×0.25mm²) | 5–15m | 2–3 €/m | For extending sensor reach; **twisted-pair shielded** preferred | Reichelt |
+| 29 | **Heat shrink tubing** (assorted, 3:1 ratio) | 1 set | 3–5 € | For sealing cable connections against moisture | Amazon |
+| 30 | **Cable clips** (for pipe mounting) | 10+ | 2–3 € | Fix sensor cable along pipe runs | Hardware store |
+| 31 | **Thermal conductive paste** (heat sink compound) | 1 tube | 3–5 € | Improves thermal contact between probe and pipe | Reichelt |
+| 32 | **Cable junction box** (IP44+) | 1 | 3–5 € | For connecting sensor extension cables | Hardware store |
+
+| | **Subtotal (sensor installation)** | | **~25–45 €** | |
+| | *Depends strongly on cable lengths needed* | | | |
+
+---
+
+## 5. Tools & Consumables
+
+Essential tools for assembly — not included in the controller cost.
+
+| # | Tool | Est. Price | Required? | Notes |
+|---|------|:----------:|:---------:|------|
+| 33 | **Digital multimeter** | 15–30 € | ✅ **Yes** | Must measure DC voltage, continuity, resistance |
+| 34 | **Wire stripper** (automatic) | 8–15 € | ✅ **Yes** | For stripping 0.75–2.5mm² wires |
+| 35 | **Screwdriver set** (slotted + Phillips) | 5–10 € | ✅ Yes | For terminal blocks and DIN rail components |
+| 36 | **Soldering iron** (30W+) | 15–25 € | ⬜ Optional | Only if you solder sensor extensions |
+| 37 | **Heat gun** | 15–30 € | ⬜ Optional | For heat shrink tubing |
+| 38 | **Cable tester** (continuity tester) | 5–10 € | ⬜ Optional | For verifying wired connections |
+
+| | **Subtotal (tools)** | | **~60–100 €** | |
+| | *May be partially available in your workshop* | | | |
+
+---
+
+## Order of Purchase
+
+If you are ordering everything at once, here is the priority:
+
+1. **Must-have (ESP32, relay, sensors, resistors, breadboard, PSU)** — ~35 €
+   → Enough to flash firmware and test sensors
+2. **Enclosure + glands + DIN rail** — ~25 €
+   → For permanent installation
+3. **Electrical (RCD, MCB, cable, terminals)** — ~60 €
+   → Only if you need to extend your distribution panel
+4. **Sensor installation (cable, heat shrink)** — ~25 €
+   → Only if running sensors to distant pipe locations
+
+You can start with just the **must-have items** (category 1) and expand later.
+
+---
+
+## Sourcing Tips
+
+| Item | Tip |
+|------|-----|
+| **ESP32** | Buy from AZ-Delivery (Germany) — known quality, fast shipping. Avoid "ESP32 WROOM" from no-name sellers. |
+| **DS18B20** | Search for "DS18B20 sanitary sensor" — these have better sealing. Cheap ones (<2€) often fail after 1–2 seasons. |
+| **Relay module** | Ensure it says **optocoupler isolated** and **active-low**. HW-279 is the most reliable model. |
+| **RCD / FI** | Buy from Hager, ABB, Schneider, or Siemens. Avoid no-name safety switches. |
+| **Cable** | NYM-J is standard for fixed installation. LiYY is for flexible internal wiring. |
+| **Resistors** | 4.7kΩ, ¼W, ±5% — literally 10 cents. Buy 10, keep spares. |
+
+---
+
+## Price Summary
+
+| Category | Main Components | Price Range |
+|----------|----------------|-------------|
+| Controller Electronics | ESP32, relay, sensors, breadboard, PSU | **35–55 €** |
+| Enclosure & Mechanics | Enclosure, glands, DIN rail, fittings | **25–45 €** |
+| Electrical (230V) | RCD, MCB, cable, terminals, ferrules | **60–110 €** |
+| Sensor Installation | Extra cable, heat shrink, junction box | **25–45 €** |
+| Tools | Multimeter, stripper, screwdrivers | **60–100 €** |
+| **Total (controller only)** | Categories 1–2 | **60–100 €** |
+| **Total (full installation)** | Categories 1–4 | **145–255 €** |
+| **Including tools** | Categories 1–5 | **205–355 €** |
+
+> 💡 The existing "Getting Started" BOM estimates **45–75 €** for the **controller electronics + enclosure** (categories 1+2). The expanded BOM above adds the **electrical installation (230V)** and **sensor mounting** materials which are necessary for a real pool installation.


### PR DESCRIPTION
## Summary

Adds a comprehensive **Bill of Materials** page with 38 line items across 5 categories, sourcing tips, and price breakdowns. Closes #18.

## Changes

| File | Description |
|------|-------------|
| `content/docs/bom/_index.md` (new) | EN BOM — 38 items in 5 categories |
| `content/docs/bom/_index.de.md` (new) | DE translation |
| `content/docs/_index.md` | Added BOM link to module list |
| `content/docs/_index.de.md` | Added Stückliste link |

## Price Summary

- Controller-only: 60–100€
- Full installation (incl. 230V): 145–255€
- Including tools: 205–355€

Closes #18