### PR TITLE
docs: add quick start guide (#16)

### DIFF
--- a/content/docs/_index.de.md
+++ b/content/docs/_index.de.md
@@ -9,6 +9,8 @@ weight: 1
 
 Dieses Projekt ist in verschiedene Module aufgeteilt:
 
+- **[Schnellstart](/docs/quickstart/)**:
+  Vom Karton bis zum laufenden Pool in 60 Minuten — der Express-Aufbau.
 - **[Pool Controller](/docs/pool-controller/)**:
   Das Herz der Steuerung — zentrale Steuerlogik auf ESP32-Basis.
 - **[Home Assistant Integration](/docs/home-assistant-integration/)**:

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -9,6 +9,8 @@ weight: 1
 
 This project is split into several modules:
 
+- **[Quick Start](/docs/quickstart/)**:
+  From box to a working pool in 60 minutes — the express build guide.
 - **[Pool Controller](/docs/pool-controller/)**:
   The heart of the 🏊 Smart Swimming Pool — ESP32-based central control logic.
 - **[Home Assistant Integration](/docs/home-assistant-integration/)**:

--- a/content/docs/quickstart/_index.de.md
+++ b/content/docs/quickstart/_index.de.md
@@ -1,0 +1,208 @@
+---
+title: Schnellstart
+weight: 8
+tags: ["docs", "getting-started", "quickstart", "tutorial"]
+---
+
+**🏊 Smart Swimming Pool: Vom Karton bis zum laufenden Pool in 60 Minuten.**
+
+Dies ist der Express-Pfad — minimale Theorie, maximale Aktion. Führen Sie jeden Schritt genau aus, und Sie haben innerhalb einer Stunde einen funktionierenden Pool-Controller.
+
+> 📖 Ausführliche Erklärungen im [Erste Schritte](/docs/getting-started/)-Handbuch.
+
+---
+
+## Was Sie brauchen
+
+- ESP32 DevKit V1 + USB-Kabel (Datenkabel!)
+- 2-Kanal 5V Relais-Modul (Aktiv-Low)
+- 2× DS18B20 Temperatursensoren (wasserdicht)
+- 2× 4,7kΩ Widerstände
+- Breadboard + Jumper-Kabel
+- 5V USB-Netzteil (1A+)
+- Computer mit VS Code + PlatformIO
+- MQTT-Broker im Netzwerk (optional für ersten Test)
+
+**Alle Teile: ~45–75 €** — siehe [Stückliste (BOM)](/docs/bom/).
+
+---
+
+## Schritt 1: Verkabeln (5 Minuten)
+
+### Breadboard-Aufbau
+
+```
+┌─────────────────────────────────────────┐
+│  ESP32 DevKit                           │
+│  ┌──────────────────────────────────────┤
+│  │ USB    GND  5V  GPIO32  GPIO33  ... │
+│  └──────────────────────────────────────┤
+│           │    │    │       │           │
+│           │    │    ├──4,7kΩ─┤ 3,3V    │
+│           │    │    │       │           │
+│  ─────────┤    │    │       │           │
+│  DS18B20 #1   │    │   DS18B20 #2       │
+│  (Solar)      │    │   (Pool)           │
+└─────────────────────────────────────────┘
+```
+
+**Verbindungen:**
+
+| Von | Nach | Farbe |
+|-----|------|-------|
+| ESP32 3,3V | DS18B20 #1 VDD (rot) | Rot |
+| ESP32 3,3V | DS18B20 #2 VDD (rot) | Rot |
+| ESP32 GND | DS18B20 #1 GND (schwarz) | Schwarz |
+| ESP32 GND | DS18B20 #2 GND (schwarz) | Schwarz |
+| ESP32 GPIO32 | DS18B20 #1 DATA (gelb) | Gelb |
+| ESP32 GPIO33 | DS18B20 #2 DATA (gelb) | Gelb |
+| GPIO32 → 3,3V | 4,7kΩ Pull-Up | — |
+| GPIO33 → 3,3V | 4,7kΩ Pull-Up | — |
+| ESP32 5V (VIN) | Relais-Modul VCC | Rot |
+| ESP32 GND | Relais-Modul GND | Schwarz |
+| ESP32 GPIO26 | Relais IN1 (Heizpumpe) | Blau |
+| ESP32 GPIO25 | Relais IN2 (Filterpumpe) | Grün |
+
+> ⚠️ **Doppelprüfung:** Relais VCC geht an **5V** (ESP32 VIN), NICHT an 3,3V.
+
+---
+
+## Schritt 2: Firmware flashen (10 Minuten)
+
+1. VS Code mit PlatformIO-Erweiterung öffnen
+2. Pool-Controller klonen und öffnen:
+   ```bash
+   git clone https://github.com/smart-swimmingpool/pool-controller.git
+   cd pool-controller
+   code .
+   ```
+3. ESP32 per USB verbinden
+4. **Firmware hochladen:** PlatformIO-Fußleiste → **→ (Upload and Monitor)** neben `esp32dev`
+5. **Dateisystem hochladen:** PlatformIO-Tab → `esp32dev` → **Platform → Upload Filesystem Image**
+6. Auf Abschluss beider Uploads warten
+
+**Erwartete Ausgabe (115200 Baud):**
+```
+[INFO] Pool Controller v3.x.x starting...
+[INFO] WiFi: Starting in AP mode
+[INFO] AP: 'Pool-Controller-Setup'. IP: 192.168.4.1
+[INFO] OneWire: Found 2 DS18B20 sensor(s)
+```
+
+---
+
+## Schritt 3: WLAN konfigurieren (3 Minuten)
+
+1. Mit WLAN **`Pool-Controller-Setup`** verbinden (offen, kein Passwort)
+2. Browser öffnen → **http://192.168.4.1**
+3. WLAN-Name und Passwort des Heimnetzes eingeben
+4. **Save** klicken — ESP32 startet neu und verbindet sich mit dem Heimnetz
+
+---
+
+## Schritt 4: MQTT verbinden (3 Minuten)
+
+1. IP-Adresse des ESP32 im Router ermitteln (oder serielle Monitor-Ausgabe)
+2. **http://<esp32-ip>/** im Browser öffnen
+3. **Configuration → MQTT**
+4. MQTT-Broker-Adresse eintragen (z.B. `192.168.1.100` oder `core-mosquitto`)
+5. Bei Authentifizierung: Benutzername/Passwort eintragen
+6. **Test Connection** — sollte "Connected" anzeigen
+7. **Save** klicken
+
+**Kein Broker?** [Mosquitto](https://mosquitto.org/download/) installieren oder das Mosquitto-Add-on in Home Assistant nutzen.
+
+---
+
+## Schritt 5: Sensoren prüfen (3 Minuten)
+
+Weboberfläche **Status**-Seite prüfen:
+
+| Sensor | Erwartet |
+|--------|----------|
+| **Pooltemperatur** | Plausible Raum-/Wassertemperatur (nicht -127°C) |
+| **Solartemperatur** | Plausible Raum-/Wassertemperatur (nicht -127°C) |
+| **Solar Sensor Found** | ✅ Ja |
+| **Pool Sensor Found** | ✅ Ja |
+
+**Anzeige -127°C?** Pull-Up-Widerstand und Datenleitung prüfen.
+
+---
+
+## Schritt 6: Relais testen (5 Minuten, OHNE 230V)
+
+1. Webinterface **Control** → **Operation Mode** auf **`manu`** (Manuell)
+2. Multimeter auf Gleichspannung einstellen
+3. **Heating Pump** EIN schalten:
+   - GPIO26 (Relais IN1) sollte **~0V (LOW)** anzeigen
+4. EIN → AUS:
+   - GPIO26 sollte wieder **~3,3V (HIGH)** anzeigen
+5. Wiederholung für **Filter Pump** an GPIO25
+
+**Spannungen vertauscht?** Relais ist Aktiv-High → Jumper (HIGH/LOW) am Modul suchen oder Modul ersetzen.
+
+---
+
+## Schritt 7: Pumpen anschließen (10 Minuten)
+
+> ⚠️ **230V Netzspannung — Lebensgefahr.** Alle Sicherheitsvorkehrungen beachten.
+
+1. **ESP32 vom USB trennen**
+2. Relaisausgänge mit Pumpen-Schützen oder direkt mit Pumpen verdrahten
+3. **FI-Schutzschalter** auf der 230V-Seite sicherstellen
+4. ESP32 wieder an USB anschließen
+5. **Operation Mode** auf **`manu`** (Manuell)
+6. **Heating Pump** EIN — Pumpe läuft
+7. AUS — Pumpe stoppt
+8. Wiederholung für **Filter Pump**
+
+---
+
+## Schritt 8: Automatik aktivieren (2 Minuten)
+
+1. **Operation Mode** auf **`auto`**
+2. **Max. Pool Temp** auf Zieltemperatur (z.B. 28°C)
+3. **Min. Solar Temp** (z.B. 35°C)
+4. **Hysterese** (z.B. 2 K)
+
+Der Controller arbeitet jetzt vollautomatisch.
+
+---
+
+## Schritt 9: Home Assistant verbinden (5 Minuten)
+
+Falls Home Assistant genutzt wird:
+
+1. **Einstellungen → Geräte & Dienste → Integration hinzufügen → MQTT**
+2. `discovery: true` sicherstellen (Standard)
+3. **Pool Controller** erscheint automatisch als neues Gerät
+4. Entities zum Lovelace-Dashboard hinzufügen
+
+Siehe [Home Assistant Integration](/docs/home-assistant-integration/) für Dashboard-Einrichtung und Automationsbeispiele.
+
+---
+
+## Fertig! 🎉
+
+Ihr Pool-Controller ist betriebsbereit. Nächste Schritte:
+
+- **[Grafana Dashboard](/docs/grafana-dashboard/)** für Temperaturverlauf einrichten
+- **[Pool Monitor](/docs/pool-monitor/)** für kabelloses Display hinzufügen
+- **[Inbetriebnahme-Checkliste](/docs/checklist/)** für ausführlichere Prüfung durchgehen
+- **[FAQ & Fehlerbehebung](/docs/troubleshooting/)** bei Problemen
+
+---
+
+## Kurzreferenz: Pin-Belegung
+
+| Komponente | ESP32 Pin |
+|-----------|-----------|
+| DS18B20 Solar (DATA) | GPIO32 |
+| DS18B20 Pool (DATA) | GPIO33 |
+| 4,7kΩ Pull-Up (pro Sensor) | DATA → 3,3V |
+| Relais IN1 (Heizpumpe) | GPIO26 |
+| Relais IN2 (Filterpumpe) | GPIO25 |
+| Relais VCC | 5V (VIN) |
+| Relais GND | GND |
+| DS18B20 VDD | 3,3V |
+| DS18B20 GND | GND |

--- a/content/docs/quickstart/_index.md
+++ b/content/docs/quickstart/_index.md
@@ -1,0 +1,208 @@
+---
+title: Quick Start
+weight: 8
+tags: ["docs", "getting-started", "quickstart", "tutorial"]
+---
+
+**🏊 Smart Swimming Pool: From box to a working pool in 60 minutes.**
+
+This is the express path — minimal theory, maximum action. Follow each step exactly, and you will have a working pool controller within an hour.
+
+> 📖 For detailed explanations and background, see the [Getting Started guide](/docs/getting-started/).
+
+---
+
+## What You Need
+
+- ESP32 DevKit V1 + USB cable (data cable!)
+- 2-channel 5V relay module (active-low)
+- 2× DS18B20 temperature sensors (waterproof)
+- 2× 4.7kΩ resistors
+- Breadboard + jumper wires
+- 5V USB power supply (1A+)
+- Computer with VS Code + PlatformIO installed
+- MQTT broker running on your network (optional for first test)
+
+**All parts: ~45–75 €** — see [Bill of Materials](/docs/bom/) for details.
+
+---
+
+## Step 1: Wire It Up (5 minutes)
+
+### Breadboard Layout
+
+```
+┌─────────────────────────────────────────┐
+│  ESP32 DevKit                           │
+│  ┌──────────────────────────────────────┤
+│  │ USB    GND  5V  GPIO32  GPIO33  ... │
+│  └──────────────────────────────────────┤
+│           │    │    │       │           │
+│           │    │    ├──4.7kΩ─┤ 3.3V     │
+│           │    │    │       │           │
+│  ─────────┤    │    │       │           │
+│  DS18B20 #1   │    │   DS18B20 #2       │
+│  (Solar)      │    │   (Pool)           │
+└─────────────────────────────────────────┘
+```
+
+**Connections:**
+
+| From | To | Wire |
+|------|-----|------|
+| ESP32 3.3V | DS18B20 #1 VDD (red) | Red |
+| ESP32 3.3V | DS18B20 #2 VDD (red) | Red |
+| ESP32 GND | DS18B20 #1 GND (black) | Black |
+| ESP32 GND | DS18B20 #2 GND (black) | Black |
+| ESP32 GPIO32 | DS18B20 #1 DATA (yellow) | Yellow |
+| ESP32 GPIO33 | DS18B20 #2 DATA (yellow) | Yellow |
+| GPIO32 → 3.3V | 4.7kΩ pull-up resistor | — |
+| GPIO33 → 3.3V | 4.7kΩ pull-up resistor | — |
+| ESP32 5V (VIN) | Relay module VCC | Red |
+| ESP32 GND | Relay module GND | Black |
+| ESP32 GPIO26 | Relay IN1 (heating pump) | Blue |
+| ESP32 GPIO25 | Relay IN2 (filter pump) | Green |
+
+> ⚠️ **Double-check:** Relay VCC goes to **5V** (ESP32 VIN pin), NOT to 3.3V.
+
+---
+
+## Step 2: Flash the Firmware (10 minutes)
+
+1. Open VS Code with the PlatformIO extension installed
+2. Clone and open the pool-controller:
+   ```bash
+   git clone https://github.com/smart-swimmingpool/pool-controller.git
+   cd pool-controller
+   code .
+   ```
+3. Connect the ESP32 via USB
+4. **Upload firmware:** In the PlatformIO footer bar, click the **→ (Upload and Monitor)** button next to `esp32dev`
+5. **Upload filesystem:** PlatformIO tab → `esp32dev` → **Platform → Upload Filesystem Image**
+6. Wait for both uploads to complete
+
+**Expected serial output (115200 baud):**
+```
+[INFO] Pool Controller v3.x.x starting...
+[INFO] WiFi: Starting in AP mode
+[INFO] AP: 'Pool-Controller-Setup'. IP: 192.168.4.1
+[INFO] OneWire: Found 2 DS18B20 sensor(s)
+```
+
+---
+
+## Step 3: Configure WiFi (3 minutes)
+
+1. Connect your phone/laptop to the WiFi network **`Pool-Controller-Setup`** (open, no password)
+2. Open browser → **http://192.168.4.1**
+3. Enter your home WiFi SSID and password
+4. Click **Save** — the ESP32 reboots and connects to your network
+
+---
+
+## Step 4: Connect to MQTT (3 minutes)
+
+1. Find the ESP32's IP address on your router (or from the serial monitor)
+2. Open **http://<esp32-ip>/** in your browser
+3. Go to **Configuration → MQTT**
+4. Enter your MQTT broker address (e.g., `192.168.1.100` or `core-mosquitto`)
+5. If using authentication, enter username/password
+6. Click **Test Connection** — it should say "Connected"
+7. Click **Save**
+
+**No broker yet?** Install [Mosquitto](https://mosquitto.org/download/) on any machine on your network, or use the Mosquitto add-on in Home Assistant.
+
+---
+
+## Step 5: Verify Sensors (3 minutes)
+
+Check the web interface **Status** page:
+
+| Sensor | Expected |
+|--------|----------|
+| **Pool Temperature** | Plausible room/water temperature (not -127°C) |
+| **Solar Temperature** | Plausible room/water temperature (not -127°C) |
+| **Solar Sensor Found** | ✅ Yes |
+| **Pool Sensor Found** | ✅ Yes |
+
+**Reading -127°C?** Check the pull-up resistor and data wire connections.
+
+---
+
+## Step 6: Test Relays (5 minutes, NO 230V)
+
+1. On the web interface **Control** page, set **Operation Mode** to **`manu`** (Manual)
+2. Grab a multimeter, set to DC voltage
+3. Toggle **Heating Pump** ON:
+   - GPIO26 (Relay IN1) should read **~0V (LOW)**
+4. Toggle ON → OFF:
+   - GPIO26 should go back to **~3.3V (HIGH)**
+5. Repeat for **Filter Pump** on GPIO25
+
+**Voltages reversed?** Your relay is active-high → check for a HIGH/LOW jumper on the module, or replace it.
+
+---
+
+## Step 7: Connect Pumps (10 minutes)
+
+> ⚠️ **230V mains voltage — risk of death.** Observe all safety precautions.
+
+1. **Disconnect** ESP32 from USB power
+2. Wire relay outputs to pump contactors or directly to pumps
+3. Ensure **RCD/FI circuit breaker** is installed on the 230V side
+4. Reconnect ESP32 to USB power
+5. Set **Operation Mode** to **`manu`** (Manual)
+6. Toggle **Heating Pump** ON — pump should start
+7. Toggle OFF — pump should stop
+8. Repeat for **Filter Pump**
+
+---
+
+## Step 8: Enable Automation (2 minutes)
+
+1. Set **Operation Mode** to **`auto`**
+2. Set **Max. Pool Temp** to your target (e.g., 28°C)
+3. Set **Min. Solar Temp** (e.g., 35°C)
+4. Set **Hysteresis** (e.g., 2 K)
+
+The controller now handles everything automatically.
+
+---
+
+## Step 9: Connect to Home Assistant (5 minutes)
+
+If you use Home Assistant:
+
+1. Go to **Settings → Devices & Services → Add Integration → MQTT**
+2. Ensure `discovery: true` is set (default)
+3. The **Pool Controller** should appear as a new device automatically
+4. Add entities to your Lovelace dashboard
+
+See the [Home Assistant Integration Guide](/docs/home-assistant-integration/) for the complete dashboard setup and automation examples.
+
+---
+
+## You're Done! 🎉
+
+Your pool controller is now fully operational. Next steps:
+
+- Set up the **[Grafana Dashboard](/docs/grafana-dashboard/)** for temperature history
+- Add the **[Pool Monitor](/docs/pool-monitor/)** for a wireless display
+- Follow the **[Commissioning Checklist](/docs/checklist/)** for a more thorough verification
+- Read the **[FAQ & Troubleshooting](/docs/troubleshooting/)** if something isn't working
+
+---
+
+## Quick Reference: Pin Map
+
+| Component | ESP32 Pin |
+|-----------|-----------|
+| DS18B20 Solar (DATA) | GPIO32 |
+| DS18B20 Pool (DATA) | GPIO33 |
+| 4.7kΩ pull-up (each) | DATA → 3.3V |
+| Relay IN1 (heating pump) | GPIO26 |
+| Relay IN2 (filter pump) | GPIO25 |
+| Relay VCC | 5V (VIN) |
+| Relay GND | GND |
+| DS18B20 VDD | 3.3V |
+| DS18B20 GND | GND |


### PR DESCRIPTION
## Summary

Adds a concise **Quick Start** guide covering the entire setup in 9 actionable steps — designed for users who want a working pool controller in under 60 minutes.

Closes #16

## Changes

| File | Description |
|------|-------------|
| `content/docs/quickstart/_index.md` (new) | EN — 9 steps: wiring → flash → WiFi → MQTT → sensors → relay → pumps → automation → HA |
| `content/docs/quickstart/_index.de.md` (new) | DE — complete translation |
| `content/docs/_index.md` | Added Quick Start link to module overview |
| `content/docs/_index.de.md` | Added Schnellstart link |

## Design

- Minimal theory, maximum action — each step has a time estimate
- Links to Getting Started, BOM, Checklist, and HA Integration for details
- Includes ASCII breadboard diagram and quick-reference pin map
- Mandatory 230V safety warning before pump connection step