### PR TITLE
docs: expand troubleshooting with heating, sensor, and firmware update scenarios (#21)

### DIFF
--- a/content/docs/troubleshooting/_index.de.md
+++ b/content/docs/troubleshooting/_index.de.md
@@ -43,6 +43,47 @@ Vermeiden Sie: Module ohne Optokopler-Isolation (einzeltransistor-getrieben) —
 
 ---
 
+## Heizungs- & Zirkulationsprobleme
+
+### Solarpumpe startet nie / Pool heizt nicht auf
+
+**Prüfen Sie in dieser Reihenfolge:**
+
+1. **Solartemperatur > Pooltemperatur?** Die Heizlogik aktiviert nur, wenn der Solarkollektor wärmer ist als das Poolwasser. Liest der Solar-Sensor niedrigere Werte als der Pool-Sensor, erfolgt keine Heizung — das ist bei Bewölkung oder nachts korrekt.
+
+2. **Hysterese zu hoch eingestellt?** Die Standard-Hysterese beträgt 2 K. Bei >5 K benötigt der Controller eine große Temperaturdifferenz zum Einschalten. Versuchen Sie 1–2 K.
+
+3. **Min. Solar Temp zu hoch?** Wenn der Parameter **Min. Solar Temp** über der tatsächlichen Kollektortemperatur liegt, wird der Heizkreis blockiert. Zum Test auf 20–25°C senken.
+
+4. **Sensoren vertauscht?** Wenn Solar- und Pool-Sensor an den falschen GPIO-Pins angeschlossen sind, liest der Controller die falschen Temperaturen. Prüfen Sie:
+   - GPIO32 = Solarkollektor (sollte bei Sonne wärmer sein)
+   - GPIO33 = Poolwasser (sollte näher an Umgebungstemperatur sein)
+   - **Status**-Seite in der Weboberfläche zum Vergleich der Werte
+
+5. **Heizkreis deaktiviert?** In der Weboberfläche **Configuration → Heating** prüfen, ob der Heizkreis **aktiviert** ist.
+
+6. **Motorventil geschlossen?** Falls ein Motorventil im Heizkreis verbaut ist, prüfen ob es geöffnet ist (separates Relais oder manuell).
+
+### Pumpe schaltet im Auto-Modus nicht
+
+Der Pool-Controller aktiviert Pumpen im Automatik-Modus nur unter bestimmten Bedingungen:
+
+- **Filterpumpe:** Läuft nach Zeitplan (Timer oder temperaturbasiert). Läuft nur innerhalb des eingestellten Zeitfensters.
+- **Heizpumpe:** Nur wenn Solartemperatur > Pooltemperatur + Hysterese, UND Pooltemperatur < max. Pooltemperatur.
+
+**Logik prüfen:**
+1. **Operation Mode** auf **`manu`** (Manuell) in der Weboberfläche **Control**-Seite
+2. Jede Pumpe manuell ein- und ausschalten — bestätigt, dass Relais und Verkabelung funktionieren
+3. Zurück auf **`auto`** schalten und beobachten: ggf. wartet der Controller nur auf Bedingungen
+
+### Eine Pumpe funktioniert, die andere nicht
+
+- Verkabelung der betroffenen Pumpe auf der 230V-Seite prüfen (LS, FI, Schütz)
+- Relais-Kanäle in der Weboberfläche tauschen (folgt die Pumpe dem getauschten Kanal, liegt das Problem auf der 230V-Seite; wenn nicht, ist der Relais-Kanal defekt)
+- Spannung an den Relais-Ausgangsklemmen beim Schalten messen
+
+---
+
 ## Temperatursensor-Probleme
 
 ### DS18B20 wird nicht erkannt / zeigt -127°C oder 85°C
@@ -69,6 +110,17 @@ Vermeiden Sie: Module ohne Optokopler-Isolation (einzeltransistor-getrieben) —
 - **Störungen:** Das Sensorkabel verläuft möglicherweise zu nah an 230V-Kabeln. Verlegen Sie das Sensorkabel mindestens 30cm entfernt von Netzleitung.
 - **Defekter Sensor:** Sensor ersetzen — kosten ~3€.
 - **Feuchtigkeit:** Wenn die Edelstahlsonde nicht vollständig eingetaucht ist oder das Kabelende nass ist, können die Werte unplausibel sein. Trocknen lassen und mit Schrumpfschlauch abdichten.
+
+### Temperaturwerte schwanken / springen unregelmäßig
+
+**Wahrscheinliche Ursache:** Elektrische Störungen oder lockerer Kontakt auf der DATA-Leitung.
+
+**Lösungen:**
+1. **DATA-Verbindung prüfen:** Ein loses Jumper-Kabel auf dem Breadboard kann intermittierenden Kontakt verursachen. Kabel fest in das Breadboard drücken.
+2. **Sensorkabel von 230V fernhalten:** Mindestens **30 cm** Abstand zu Netzleitungen. Parallele Verlegung über längere Strecken verstärkt Störungen.
+3. **Geschirmtes Kabel verwenden:** Bei Verlängerungen >5 m **geschirmte Twisted-Pair-Kabel** (z.B. LiYCY 2×0,25mm²) nutzen. Schirm nur auf ESP32-Seite an GND anschließen.
+4. **Pull-Up-Widerstand prüfen:** Widerstand zwischen DATA und 3,3V messen — sollte ~4,7 kΩ betragen.
+5. **Wasser in der Verbindungsdose?:** Bei Verlängerungskabeln kann die Verbindungsdose Kondenswasser enthalten. Öffnen, trocknen und mit Schrumpfschlauch oder Silikon abdichten.
 
 ### Beide Sensoren zeigen dieselbe Temperatur
 
@@ -135,6 +187,39 @@ Das ist normal, wenn sie im Wasser auf gleicher Temperatur liegen. Zur Überprü
 - Prüfen Sie die Firewall-Regeln: Port 1883 (TCP) muss zwischen ESP32 und Broker offen sein.
 - Bei Authentifizierung: Benutzername und Passwort in der MQTT-Konfiguration des Controllers prüfen.
 
+### Pumpenschalter reagieren nicht auf Home Assistant
+
+**Wahrscheinliche Ursache:** Der Controller akzeptiert Pumpenbefehle per MQTT nur im **Manuell**-Modus.
+
+**Lösungen:**
+1. **Operation Mode** auf **`manu`** in Home Assistant stellen (`select.pool_controller_mode`)
+2. Die Pumpenschalter sollten jetzt schreibbar sein
+3. Nach manueller Steuerung zurück auf `auto` für automatischen Betrieb
+
+Wenn die Schalter auch im `manu`-Modus nicht reagieren:
+1. MQTT-**Verfügbarkeits-Topic** prüfen: `homeassistant/sensor/pool-controller/availability` sollte `online` anzeigen
+2. Stale-Discovery löschen: Leeres Payload an das `/config`-Topic der Entity senden
+3. Controller über die Weboberfläche neu starten
+
+---
+
+## Controller & Automatisierungsprobleme
+
+### Controller schaltet Pumpen nicht, obwohl Bedingungen erfüllt sind
+
+**Prüfen Sie:**
+
+1. **Ist der Betriebsmodus auf `auto`?** Im Modus `manu` (Manuell) automatisiert der Controller nicht. Im Modus `timer` läuft nur der Timer-Zeitplan. Nur `auto` nutzt die vollständige Heizlogik.
+2. **Status-Seite prüfen:** Die Weboberfläche **Status** zeigt den aktuellen Zustand aller Sensoren und die Entscheidungslogik des Controllers. Wenn der Controller Bedingungen als nicht erfüllt ansieht, ist der Grund hier sichtbar.
+3. **MQTT-Befehl anhängig?** Wenn Sie kürzlich eine Pumpe via Home Assistant geschaltet haben, überschreibt ein MQTT-Befehl ggf. den Automatik-Zustand. Pumpe AUS und zurück auf AUTO schalten oder Controller neu starten.
+4. **Firmware-Fehler?** GitHub Issues für Ihre Firmware-Version prüfen.
+
+### Modus-Wahl lässt sich nicht ändern / springt zurück
+
+- Der Controller speichert den Modus im Flash-Speicher. Wenn der Modus nach Sekunden zurückspringt, kann das Schreiben fehlschlagen.
+- Controller neu starten und erneut versuchen.
+- Bei anhaltendem Problem: Firmware neu flashen (Konfiguration bleibt in den meisten Fällen erhalten).
+
 ---
 
 ## ESP32- & Firmware-Probleme
@@ -167,6 +252,23 @@ rst:0xc (SW_CPU_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
 
 - Falsche Baudrate — stellen Sie sie auf **115200** ein.
 - Falsche Spannung — ESP32 arbeitet mit 3,3V. Wenn Sie ihn an einen Arduino Uno angeschlossen haben, könnte die serielle Schnittstelle beschädigt sein.
+
+### Controller nach Firmware-Update nicht erreichbar
+
+**Wahrscheinliche Ursache:** Das Update hat die WLAN-Konfiguration zurückgesetzt oder die IP-Adresse geändert.
+
+**Lösungen:**
+1. **WLAN-Zugangsdaten zurückgesetzt.** Nach manchen Updates fällt der Controller in den AP-Modus zurück (`Pool-Controller-Setup`). Mit diesem Netzwerk verbinden und WLAN über die Weboberfläche unter `http://192.168.4.1` neu konfigurieren.
+2. **IP-Adresse geändert.** DHCP-Client-Liste des Routers nach einer neuen IP durchsuchen. Der Controller kann nach dem Flashen eine andere MAC-Adresse haben, wenn die NVS-Partition gelöscht wurde.
+3. **OTA-Update fehlgeschlagen.** War das OTA-Update unterbrochen oder die neue Firmware defekt, kann der Controller in einer Boot-Schleife hängen. Wiederherstellung erfordert **serielles (USB-) Flashen**:
+   - ESP32 per USB verbinden
+   - BOOT-Taste gedrückt halten
+   - Firmware via PlatformIO wie gewohnt flashen
+4. **Partitionslayout geändert.** Bei geändertem Partitionsschema kann das Dateisystem (Weboberfläche) fehlen oder beschädigt sein. Dateisystem-Image erneut hochladen:
+   ```bash
+   pio run -e esp32dev -t uploadfs
+   ```
+5. **Vorbeugung:** Vor OTA-Update sicherstellen, dass der ESP32 in WLAN-Reichweite ist und eine stabile Stromversorgung hat. Update nicht unterbrechen.
 
 ---
 

--- a/content/docs/troubleshooting/_index.md
+++ b/content/docs/troubleshooting/_index.md
@@ -43,6 +43,47 @@ Avoid: modules without optocoupler isolation (single-transistor driven) — they
 
 ---
 
+## Heating & Circulation Issues
+
+### Solar pump never starts / pool does not heat up
+
+**Check these in order:**
+
+1. **Solar temperature > pool temperature?** The heating logic only activates when the solar collector is warmer than the pool water. If the solar sensor reads lower than the pool sensor, no heating occurs — this is correct behavior on cloudy days or at night.
+
+2. **Hysteresis setting too high?** The default hysteresis is 2 K. If it's set to >5 K, the controller needs a large temperature difference before switching on. Try lowering it to 1–2 K.
+
+3. **Min. Solar Temp too high?** If the **Min. Solar Temp** parameter is set above the actual solar collector temperature, the heating circuit is blocked regardless of other settings. Try lowering it to 20–25°C for testing.
+
+4. **Sensors swapped?** If the solar sensor and pool sensor cables are connected to the wrong GPIO pins, the controller will read the wrong temperatures. Verify:
+   - GPIO32 = solar collector (should be warmer when the sun shines)
+   - GPIO33 = pool water (should be closer to ambient)
+   - Check the **Status** page in the web interface to compare readings
+
+5. **Heating circuit deactivated?** In the web interface **Configuration** → **Heating**, ensure the heating circuit is **enabled**. Some firmware versions allow disabling the heating circuit independently.
+
+6. **Motorised valve closed?** If your system has a motorised valve for the heating circuit, ensure it is opened (either by a separate relay or manually).
+
+### Pump does not turn on in Auto mode
+
+The pool controller only activates pumps automatically when certain conditions are met:
+
+- **Filter pump:** Runs according to the circulation schedule (timer or temperature-based). If the timer window has not started, the pump will not run.
+- **Heating pump:** Only activates when solar temperature > pool temperature + hysteresis, AND pool temperature < max. pool temperature.
+
+**To verify the logic is working:**
+1. Set **Operation Mode** to **`manu`** (Manual) on the web interface **Control** page
+2. Toggle each pump ON manually — this proves the relay and wiring are working
+3. Switch back to **`auto`** and observe: the controller may simply be waiting for conditions to be met
+
+### One pump works but the other does not
+
+- Check the specific pump's wiring on the 230V side (circuit breaker, RCD, contactor)
+- Swap the relay channels in the web interface (if the same pump follows the swapped channel, the problem is on the 230V side; if not, the relay channel is defective)
+- Measure voltage at the relay output terminals when toggled
+
+---
+
 ## Temperature Sensor Issues
 
 ### DS18B20 sensor not detected / reads -127°C or 85°C
@@ -69,6 +110,17 @@ Avoid: modules without optocoupler isolation (single-transistor driven) — they
 - **Interference:** The sensor cable may run too close to 230V power cables. Route sensor cable at least 30cm away from mains wiring.
 - **Faulty sensor:** Replace the sensor — they cost ~3€.
 - **Water ingress:** If the stainless steel probe is not fully submerged or the cable end is wet, readings can be erratic. Let it dry and seal with heat shrink.
+
+### Temperature readings fluctuate / jump erratically
+
+**Likely cause:** Electrical interference or a loose connection on the DATA line.
+
+**Solutions:**
+1. **Check the DATA connection:** A loose jumper wire on the breadboard can cause intermittent contact. Push the wire firmly into the breadboard.
+2. **Keep sensor cable away from 230V:** Route sensor cable at least **30 cm** away from mains wiring. Parallel runs over long distances amplify interference.
+3. **Use shielded cable:** For runs longer than 5 m, use **twisted-pair shielded cable** (e.g., LiYCY 2×0.25mm²). Connect the shield to GND on the ESP32 side only.
+4. **Check pull-up resistor:** A missing or incorrectly placed pull-up resistor can cause unstable readings. Measure resistance between DATA and 3.3V — it should be ~4.7 kΩ.
+5. **Check for water in the cable junction:** If using extension cables, the junction box may have condensation. Open, dry, and seal with heat shrink or silicone.
 
 ### Both sensors show the same temperature
 
@@ -135,6 +187,39 @@ This is expected if they are placed in water at the same temperature. To verify 
 - Check firewall rules: port 1883 (TCP) must be open between ESP32 and broker.
 - If using authentication, verify username and password in the controller's MQTT configuration.
 
+### Pump switches do not respond to Home Assistant
+
+**Likely cause:** The controller only accepts pump commands from MQTT in **Manual** mode.
+
+**Solutions:**
+1. Set **Operation Mode** to **`manu`** in Home Assistant (`select.pool_controller_mode`)
+2. Now the pump switches should be writable
+3. After manual control, switch back to `auto` for automated operation
+
+If the switches still do not respond in `manu` mode:
+1. Check the MQTT **availability** topic: `homeassistant/sensor/pool-controller/availability` should show `online`
+2. Verify the MQTT discovery topic was not overwritten by a stale config. Publish an empty payload to the entity's `/config` topic to clear stale discovery
+3. Reboot the controller from the web interface
+
+---
+
+## Controller & Automation Issues
+
+### Controller does not switch pumps even though conditions are met
+
+**Check these:**
+
+1. **Is the operation mode set to `auto`?** In `manu` (Manual) mode, the controller does not automate. In `timer` mode, only the timer schedule runs. Only `auto` mode uses the full heating logic.
+2. **Check the status page:** The web interface **Status** page shows the current state of all sensors and the controller's decision logic. If the controller thinks conditions are not met, the reason will be visible here.
+3. **MQTT command pending?** If you recently toggled a pump via Home Assistant, the controller may have received an MQTT command that overrides the automatic state. Toggle the pump OFF and back to AUTO or reboot the controller.
+4. **Firmware bug?** Check the GitHub Issues for your firmware version. Known issues are tracked there.
+
+### Mode selector does not change / reverts immediately
+
+- The controller persists the mode in flash memory. If the mode reverts after a few seconds, the flash write may be failing.
+- Reboot the controller and try again.
+- If the problem persists, re-flash the firmware (configuration will be preserved in most cases).
+
 ---
 
 ## ESP32 & Firmware Issues
@@ -167,6 +252,24 @@ rst:0xc (SW_CPU_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
 
 - Wrong baud rate — set it to **115200**.
 - Wrong voltage — ESP32 runs at 3.3V. If you connected it to an Arduino Uno, you may have damaged the serial interface.
+
+### Controller unreachable after firmware update
+
+**Likely cause:** The update reset the WiFi configuration or changed the device's IP address.
+
+**Solutions:**
+1. **WiFi credentials may have been reset.** After some updates, the controller falls back to AP mode (`Pool-Controller-Setup`). Connect to this network and reconfigure WiFi via the web interface at `http://192.168.4.1`.
+2. **IP address may have changed.** Check your router's DHCP client list for a new IP. The controller may have a different MAC address after flashing if the NVS partition was erased.
+3. **OTA update failed without rollback.** If the OTA update was interrupted or the new firmware is corrupted, the controller may be stuck in a boot loop. Recovery requires a **serial (USB) flash**:
+   - Connect the ESP32 via USB
+   - Hold the BOOT button
+   - Flash the firmware via PlatformIO as usual
+   - This bypasses OTA and writes directly to flash
+4. **Partition layout changed.** If the new firmware uses a different partition scheme than the old one, the filesystem (web interface) may be missing or corrupted. Re-upload the filesystem image:
+   ```bash
+   pio run -e esp32dev -t uploadfs
+   ```
+5. **Preventive measure:** Before updating via OTA, ensure the ESP32 is within WiFi range of your router and has a stable power supply. Do not interrupt the update process.
 
 ---
 


### PR DESCRIPTION
## Summary

Expands the existing FAQ & Troubleshooting page with 7 new scenarios across 4 new sections. Closes #21.

## New Sections

| Section | Scenarios | EN | DE |
|---------|-----------|:--:|:--:|
| Heating & Circulation | Solar pump not starting, auto mode conditions, one pump dead | ✅ | ✅ |
| Temperature Fluctuation | Electrical interference, loose DATA, shielded cable, water ingress | ✅ | ✅ |
| Controller Automation | Mode not changing, pumps not switching, MQTT overriding | ✅ | ✅ |
| Firmware Update Recovery | WiFi reset after update, OTA failure, partition layout change | ✅ | ✅ |
| MQTT Pumps | Switches not responding in HA, manual mode requirement | ✅ | ✅ |

Closes #21