### PR TITLE
docs: add upgrade and migration guide (#23)

### DIFF
--- a/content/docs/_index.de.md
+++ b/content/docs/_index.de.md
@@ -30,4 +30,5 @@ Geplante Module:
 
 - **[FAQ & Fehlerbehebung](/docs/troubleshooting/)** — Häufige Probleme und Lösungen
 - **[Erste Schritte](/docs/getting-started/)** — Schritt-für-Schritt-Aufbauanleitung
+- **[Upgrade & Migration](/docs/migration/)** — Firmware-Updates zwischen Versionen
 - **Community [Wiki](https://github.com/smart-swimmingpool/smart-swimmingpool/wiki)** — Zusätzliche Inhalte von der Community

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -30,4 +30,5 @@ Planned modules:
 
 - **[FAQ & Troubleshooting](/docs/troubleshooting/)** — Common problems and solutions
 - **[Getting Started](/docs/getting-started/)** — Step-by-step build guide
+- **[Upgrade & Migration](/docs/migration/)** — How to update between firmware versions
 - **Community [Wiki](https://github.com/smart-swimmingpool/smart-swimmingpool/wiki)** — Additional community-driven content

--- a/content/docs/migration/_index.de.md
+++ b/content/docs/migration/_index.de.md
@@ -1,0 +1,151 @@
+---
+title: Upgrade & Migration
+weight: 25
+tags: ["docs", "migration", "upgrade", "releases"]
+---
+
+**🏊 Smart Swimming Pool: Wie Sie die Firmware des Pool-Controllers zwischen Hauptversionen aktualisieren.**
+
+Diese Seite dokumentiert Breaking Changes, neue Parameter und Migrationsschritte zwischen Releases. Lesen Sie den entsprechenden Abschnitt **vor** dem Update.
+
+---
+
+## Kurzreferenz
+
+| Von → Nach | Typ | Breaking Changes | Migration nötig |
+|-----------|------|:----------------:|:---------------:|
+| v2.x → v3.2 | Großes Rewrite | ✅ MQTT-Protokoll, Homie → HA Discovery | Reset, neu flashen |
+| v3.2 → v3.3 | Kleines Update | Keine | Optional (Config bleibt) |
+
+---
+
+## v2.x → v3.2 (Großes Update)
+
+Veröffentlicht: Mai 2026
+
+Dieses Update ist ein **komplettes Rewrite** der Firmware. Das gesamte MQTT-Protokoll wechselte von der **Homie-Convention** zu **Home Assistant MQTT Discovery**.
+
+### Breaking Changes
+
+| Bereich | v2.x | v3.2+ | Auswirkung |
+|---------|------|-------|------------|
+| **MQTT-Protokoll** | Homie-Convention | Home Assistant MQTT Discovery | Alle MQTT-Topics geändert. Smarthome-Integrationen müssen neu konfiguriert werden |
+| **Geräte-ID** | Benutzerdefiniert | `pool_controller_<mac>` | Home Assistant erzeugt neues Gerät — altes löschen |
+| **Firmware-Ziel** | ESP8266 unterstützt | Nur ESP32 | ESP8266-Nutzer können nicht updaten; Hardware-Wechsel nötig |
+| **Konfiguration** | Webserver-basiert | Web-UI auf LittleFS | Einstellungen nicht kompatibel; Neukonfiguration nötig |
+| **Weboberfläche** | Einfache HTML-Formulare | Vollständige SPA auf LittleFS | Erfordert `uploadfs`-Schritt nach dem Flashen |
+
+### Migrationsschritte
+
+1. **Einstellungen sichern** — Screenshots der v2.x-Konfiguration machen (MQTT-Broker, Temperaturgrenzen, Timer)
+2. **Neue Firmware flashen** via USB (PlatformIO, Umgebung `esp32dev`)
+3. **Dateisystem-Image hochladen** (`pio run -e esp32dev -t uploadfs`)
+4. **Alles neu konfigurieren** via Weboberfläche (WLAN, MQTT, Temperaturgrenzen)
+5. **Home Assistant neu konfigurieren:** Neuer Controller erscheint als neues Gerät. Entities zum Dashboard hinzufügen. Altes v2.x-Gerät in HA löschen
+6. **Automationen anpassen:** MQTT-Topics haben sich geändert — alle Homie-basierten Automatisierungen aktualisieren
+7. **Überprüfen:** Alle Sensoren melden korrekte Werte, Pumpen reagieren
+
+### Was sich verbessert hat
+
+| v2.x-Einschränkung | v3.2+-Lösung |
+|--------------------|-------------|
+| Homie-Topics erforderten manuelle HA-Konfiguration | Automatischer MQTT Discovery — kein YAML nötig |
+| ESP8266 mit wenig Flash und RAM | ESP32 mit 4MB Flash, reichlich RAM |
+| Web-UI war minimalistisch | Vollständige Konfigurations-UI auf LittleFS |
+| Keine OTA-Updates | OTA von GitHub Releases (ab v3.3) |
+
+---
+
+## v3.2 → v3.3 (Kleines Update)
+
+Veröffentlicht: Juni 2026
+
+### Neue Funktionen
+
+| Funktion | Beschreibung |
+|----------|-------------|
+| **OTA-Updates** | Firmware kann via Home Assistant oder Weboberfläche aktualisiert werden. Controller prüft automatisch auf neue GitHub-Releases |
+| **NTP-Konfiguration** | NTP-Server und Zeitzone via Web-UI oder MQTT konfigurierbar — keine Compile-Zeit-Zeitzone mehr nötig |
+| **Lokale Zeit** | Controller zeigt aktuelle Ortszeit in der Diagnose an |
+| **Timer-Entities** | Timer-Start/-Ende von separaten Stunden+Minuten auf einzelne `time`-Entities umgestellt (HH:MM-Format) |
+| **Web-UI umstrukturiert** | Einstellungs-Tabs neu organisiert, HA-Entity-Kategorien aktualisiert |
+| **Config-Backup** | NVS-Konfiguration wird gesichert; MQTT-Fehler werden gemeldet |
+| **LittleFS-Mount-Fix** | Webportal mountet LittleFS jetzt korrekt beim Start |
+
+### Breaking Changes
+
+**Keine.** v3.3 ist vollständig abwärtskompatibel mit v3.2-Konfigurationen.
+
+### Migrationsschritte
+
+1. **Option A — OTA via Home Assistant:**
+   - **Einstellungen → Geräte & Dienste → Geräte → Pool Controller**
+   - Die **Firmware**-Update-Entity (`update.pool_controller_firmware`) zeigt die neue Version
+   - **Installieren** klicken — Controller lädt das Update herunter und wendet es an
+   - Auf Neustart warten
+
+2. **Option B — OTA via Weboberfläche:**
+   - Controller-Webinterface öffnen
+   - **System → Firmware Update**
+   - **Nach Updates suchen** klicken
+
+3. **Option C — USB-Flash (Fallback):**
+   - ESP32 per USB verbinden
+   - Firmware + Dateisystem wie gewohnt flashen
+   - Alle Einstellungen bleiben erhalten (NVS-Partition)
+
+### Post-Update-Prüfungen
+
+- [ ] Weboberfläche unter gleicher IP erreichbar
+- [ ] Alle Temperatursensoren zeigen korrekte Werte
+- [ ] MQTT-Verbindung hergestellt
+- [ ] Home Assistant zeigt alle Entities als verfügbar
+- [ ] Timer-Entities jetzt als einzelne HH:MM-Regler
+
+### Neue Konfigurationsparameter
+
+| Parameter | Typ | Standard | Beschreibung |
+|-----------|-----|----------|-------------|
+| `ntp_server` | Text | `pool.ntp.org` | NTP-Server für Zeitsynchronisation |
+| `timezone` | Select | `UTC` | IANA-Zeitzone (z.B. `Europe/Berlin`) |
+
+Konfiguration via:
+- Weboberfläche: **Configuration → System**
+- Home Assistant: `text.pool_controller_ntp_server`, `select.pool_controller_timezone`
+
+---
+
+## Rollback
+
+Falls ein Update Probleme verursacht, kann auf die vorherige Version zurückgesetzt werden:
+
+### v3.3 → v3.2
+
+**Einstellungen sind möglicherweise nicht kompatibel** — v3.3 führte neue Parameter (NTP, Zeitzone) ein, die v3.2 nicht kennt. v3.2 ignoriert unbekannte Parameter, daher ist ein Downgrade in der Regel sicher.
+
+1. v3.2-Firmware via USB flashen:
+   ```bash
+   git checkout v3.2.0
+   pio run -e esp32dev -t upload
+   ```
+2. v3.2-Dateisystem-Image hochladen:
+   ```bash
+   pio run -e esp32dev -t uploadfs
+   ```
+3. Neu starten und Funktion prüfen
+
+### v3.2 → v2.x
+
+**Vollständige Neukonfiguration erforderlich.** Siehe v2.x → v3.2-Migrationsschritte oben.
+
+---
+
+## Versionsgeschichte
+
+| Version | Datum | Highlights |
+|---------|-------|-----------|
+| **v3.3.0** | 2026-06-06 | OTA-Updates, NTP-Konfiguration, lokale Zeit, Timer-Entities, Web-UI-Neustrukturierung |
+| **v3.2.0** | 2026-05-22 | HA MQTT Discovery, nur ESP32, neue Web-UI, WPS-Onboarding |
+| **v2.x** | 2020–2025 | Homie-Convention, ESP8266+ESP32, openHAB-zentriert |
+
+Vollständiges Changelog auf [GitHub Releases](https://github.com/smart-swimmingpool/pool-controller/releases).

--- a/content/docs/migration/_index.md
+++ b/content/docs/migration/_index.md
@@ -1,0 +1,151 @@
+---
+title: Upgrade & Migration
+weight: 25
+tags: ["docs", "migration", "upgrade", "releases"]
+---
+
+**🏊 Smart Swimming Pool: How to update the pool controller firmware between major versions.**
+
+This page documents breaking changes, new parameters, and migration steps between releases. Always read the relevant section **before** updating.
+
+---
+
+## Quick Reference
+
+| From → To | Type | Breaking Changes | Migration Required |
+|-----------|------|:----------------:|:------------------:|
+| v2.x → v3.2 | Major rewrite | ✅ MQTT protocol, Homie → HA Discovery | Config reset, re-flash |
+| v3.2 → v3.3 | Minor update | None | Optional (config preserved) |
+
+---
+
+## v2.x → v3.2 (Major Update)
+
+Released: May 2026
+
+This update is a **major rewrite** of the firmware. The entire MQTT protocol changed from **Homie convention** to **Home Assistant MQTT Discovery**.
+
+### Breaking Changes
+
+| Area | v2.x | v3.2+ | Impact |
+|------|------|-------|--------|
+| **MQTT Protocol** | Homie convention | Home Assistant MQTT Discovery | All MQTT topics changed. Smart home integrations must be reconfigured |
+| **Device ID** | Custom | `pool_controller_<mac>` | Home Assistant creates a new device — delete the old one |
+| **Firmware target** | ESP8266 supported | ESP32 only | ESP8266 users cannot upgrade; must migrate hardware |
+| **Configuration** | Webserver-based | Web UI on LittleFS | Settings not compatible; must be reconfigured |
+| **Web interface** | Basic HTML forms | Full SPA on LittleFS | Requires `uploadfs` step after flashing |
+
+### Migration Steps
+
+1. **Back up your settings** — Take screenshots of your v2.x configuration (MQTT broker, temperature limits, timer settings)
+2. **Flash the new firmware** via USB (PlatformIO, `esp32dev` environment)
+3. **Upload the filesystem image** (`pio run -e esp32dev -t uploadfs`)
+4. **Reconfigure everything** via the new web interface (WiFi, MQTT, temperature limits)
+5. **Reconfigure Home Assistant:** The new controller appears as a new device (`Pool Controller`). Add entities to your dashboard. Delete the old v2.x device from HA
+6. **Reconfigure automation:** MQTT topics have changed — update any custom automations that referenced Homie topics
+7. **Verify** that all sensors report correct values and pumps respond
+
+### What Changed for the Better
+
+| v2.x Limitation | v3.2+ Solution |
+|-----------------|----------------|
+| Homie topics required custom HA configuration | Automatic MQTT Discovery — no YAML needed |
+| ESP8266 had limited flash and RAM | ESP32 with 4MB flash, ample RAM |
+| Web UI was bare-bones | Full configuration UI on LittleFS |
+| No OTA updates | OTA from GitHub releases (added in v3.3) |
+
+---
+
+## v3.2 → v3.3 (Minor Update)
+
+Released: June 2026
+
+### New Features
+
+| Feature | Description |
+|---------|-------------|
+| **OTA Updates** | Firmware can now be updated via Home Assistant or the web interface. The controller checks GitHub releases automatically |
+| **NTP Configuration** | Configure NTP server and timezone via web UI or MQTT — no more compile-time timezone |
+| **Local Time Display** | Controller shows current local time in diagnostics |
+| **Timer entities** | Timer start/end changed from separate hour+minute numbers to single `time` entities (HH:MM format) |
+| **Web UI restructured** | Settings tabs reorganized; HA entity categories updated |
+| **Config backup** | NVS configuration is backed up; MQTT errors are reported |
+| **LittleFS mount fix** | Web portal now correctly mounts LittleFS on startup |
+
+### Breaking Changes
+
+**None.** The v3.3 update is fully backward-compatible with v3.2 configurations.
+
+### Migration Steps
+
+1. **Option A — OTA from Home Assistant:**
+   - Go to **Settings → Devices & Services → Devices → Pool Controller**
+   - The **Firmware** update entity (`update.pool_controller_firmware`) shows the new version
+   - Click **Install** — the controller downloads and applies the update
+   - Wait for the controller to reboot
+
+2. **Option B — OTA from web interface:**
+   - Open the controller web interface
+   - Go to **System → Firmware Update**
+   - Click **Check for Updates** and follow the prompts
+
+3. **Option C — USB flash (fallback):**
+   - Connect the ESP32 via USB
+   - Flash firmware + filesystem as usual
+   - All settings are preserved (stored in NVS partition)
+
+### Post-Update Checks
+
+- [ ] Web interface reachable at the same IP address
+- [ ] All temperature sensors report correct values
+- [ ] MQTT connection established
+- [ ] Home Assistant shows all entities as available
+- [ ] Timer entities now show as single HH:MM controls
+
+### New Configuration Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ntp_server` | Text | `pool.ntp.org` | NTP server for time synchronization |
+| `timezone` | Select | `UTC` | IANA timezone (e.g., `Europe/Berlin`) |
+
+These are configured via:
+- Web interface: **Configuration → System**
+- Home Assistant: `text.pool_controller_ntp_server`, `select.pool_controller_timezone`
+
+---
+
+## Rollback
+
+If an update causes issues, you can roll back to the previous version:
+
+### v3.3 → v3.2
+
+**Settings may not be compatible** — v3.3 introduced new parameters (NTP, timezone) that v3.2 does not recognize. v3.2 will ignore unknown parameters, so downgrade is generally safe.
+
+1. Flash the v3.2 firmware via USB:
+   ```bash
+   git checkout v3.2.0
+   pio run -e esp32dev -t upload
+   ```
+2. Upload the v3.2 filesystem image:
+   ```bash
+   pio run -e esp32dev -t uploadfs
+   ```
+3. Reboot and verify everything works
+
+### v3.2 → v2.x
+
+**Full reconfiguration required.** See the v2.x → v3.2 migration steps above — the same incompatibilities apply in reverse.
+
+---
+
+## Version History
+
+| Version | Date | Highlights |
+|---------|------|-----------|
+| **v3.3.0** | 2026-06-06 | OTA updates, NTP config, local time display, timer entities, web UI restructure |
+| **v3.2.0** | 2026-05-22 | HA MQTT Discovery, ESP32-only, new web UI, WPS onboarding |
+| **v2.x** | 2020–2025 | Homie convention, ESP8266+ESP32, openHAB-centric |
+
+See the [GitHub Releases](https://github.com/smart-swimmingpool/pool-controller/releases) for the full changelog of each version.


### PR DESCRIPTION
## Summary

Adds a complete **Upgrade & Migration** guide covering all firmware version transitions. Closes #23.

## Changes

| File | Description |
|------|-------------|
| `content/docs/migration/_index.md` (new) | EN — v2.x→v3.2, v3.2→v3.3, rollback, changelog |
| `content/docs/migration/_index.de.md` (new) | DE translation |
| `content/docs/_index.md` | Added link to Help & Support |
| `content/docs/_index.de.md` | Added link |

## Contents

- Quick reference table of all version transitions
- **v2.x → v3.2**: Breaking changes (protocol, device ID, ESP8266 dropped), full migration steps
- **v3.2 → v3.3**: New features (OTA, NTP, timer entities, web UI restructure), no breaking changes
- **Rollback**: Procedures for downgrading
- **Version history** table