### PR TITLE
feat: add blog posts from Medium and AZ-Delivery series

### DIFF
--- a/content/blog/_index.de.md
+++ b/content/blog/_index.de.md
@@ -1,0 +1,5 @@
+---
+title: "Blog"
+---
+
+Entdecken Sie Artikel und Tutorials rund um das Smart Swimming Pool Projekt.

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Blog"
+---
+
+Discover articles and tutorials about the Smart Swimming Pool project.

--- a/content/blog/der-smarte-pool-4-4.de.md
+++ b/content/blog/der-smarte-pool-4-4.de.md
@@ -1,0 +1,87 @@
+---
+title: "Der smarte Pool (4/4)"
+date: 2018-10-24
+authors:
+  - name: "Stephan Strittmatter"
+    link: https://github.com/stritti
+    image: https://github.com/stritti.png
+tags:
+  - "Development"
+  - "Deutsch"
+  - "openHAB"
+---
+
+In den [vorangegangenen Artikeln]({{< relref "swimmingpool-openhab-3-4" >}}) haben wir den Pool-Controller mit openHAB verbunden. Über die Oberfläche der Sitemap in openHAB können in der Sektion Einstellungen die Parameter für die Temperaturen einfach eingestellt werden. Die Regeln reagieren auf diese Änderungen.
+
+Nun geht es darum, die Steuerung auch wirklich smart zu machen: die Regelung verläuft automatisch und kann über WLAN bzw. Internet angepasst werden.
+
+## Regelsteuerung des Pools
+
+Für die Erwärmung des Pools haben wir drei Modi implementiert:
+
+### Modus: Auto
+
+Der vollautomatische Modus schaltet die Filterpumpe zeitgesteuert und erwärmt automatisch das Poolwasser bis zu einer Maximaltemperatur. Dies jedoch nur so lange, wie die Mindesttemperatur im Wärmespeicher nicht unterschritten wird.
+
+### Modus: Boost
+
+Vergleichbar mit dem Modus "Auto", jedoch ohne Berücksichtigung der Mindesttemperatur im Wärmespeicher.
+
+### Modus: Manuell
+
+Die Pumpen werden über die App manuell ein- und ausgeschaltet. Unabhängig von Regeln und Schwellwerten.
+
+## Die Grenzwerte
+
+Für die Steuerung der Temperatur des Pools werden folgende drei Parameter benötigt:
+
+- **Maximale Pooltemperatur**: Wie warm soll der Pool werden?
+- **Minimale Wärmespeichertemperatur**: Welche Temperatur muss das Wasser im Pufferspeicher mindestens haben, damit der Pool mitgeheizt werden kann?
+- **Hysterese**: Wie groß soll die Temperaturabweichung sein, bevor die min/max-Regeln sich auswirken?
+
+## Das smarte Herz: pool.rules
+
+Die Regeln in der `pool.rules` sind die Regeln von openHAB hinterlegt. Diese Regeln verwenden die Konfigurationswerte, die man über die Einstellungen festlegen kann.
+
+Hier werden die Werte der Temperatursensoren verglichen und anhand der Hysterese dann die Funksteckdosen gesteuert. Die Hysterese ist notwendig, damit bei sehr geringen Temperaturdifferenzen die Pumpen nicht ständig ein- und ausgeschaltet werden. Ein Wert von 0,5 K hat sich als völlig ausreichend erwiesen.
+
+Die Regeln sind aufgeteilt und bedienen so die einzelnen Betriebsmodi.
+
+## Add-On: Anzeigemodul
+
+Um die Temperaturen auch ohne App zu verfolgen, haben wir eine kleine Monitoring-Anwendung in eine alte Schraubenbox gesteckt. Dieses Modul entstand auf Basis des LCD-Displays 16×2.
+
+Dieser Pool-Monitor basiert auf einem ESP8266 und einem LCD Display 16×2. Der ESP empfängt die Temperaturwerte — ebenfalls über MQTT — und aktualisiert das Display.
+
+Der Quellcode dazu befindet sich ebenfalls im Code-Repository und ist vom Pool-Controller abgeleitet.
+
+Das Gehäuse ist eine alte Schrauben-Box, die mit etwas Füllmaterial ausgepolstert wurde. Etwas tricky war die Bohrung für den Micro-USB Stecker. Vielleicht wird nächstes Jahr diese Box upgegraded und mit einer Solarzelle ausgestattet. Dann kann diese auch draußen in der Nähe des Pools installiert werden.
+
+## Open Source
+
+Ziel war es von Anfang an, ein Projekt basierend auf Open Source zu erstellen. So ist natürlich auch wieder ein Open Source Projekt entstanden.
+
+Das gesamte Projekt ist auf GitHub verfügbar:
+
+[https://github.com/stritti/smart-swimming-pool](https://github.com/stritti/smart-swimming-pool)
+
+## Fazit
+
+Der Pool-Controller ist seit Mai im Einsatz und hat nach ein paar Verbesserungen den Sommer über zuverlässig funktioniert.
+
+Hauptproblem war eigentlich die fehlende Prüfung, ob die WLAN-Verbindung noch besteht. Wir dachten immer, wir hätten irgendwo ein Leak im Code, dabei hat der ESP-Controller gelegentlich nur die Verbindung über das WLAN verloren. Jetzt läuft der Controller zuverlässig, liefert Daten und steuert die Pumpen.
+
+Seit diesem Jahr gibt es also einen schönen warmen Pool und trotzdem immer genügend warmes Wasser im Haushalt. Ein Projekt mit klarem Mehrwert an Komfort mit relativ geringem finanziellem Einsatz. Dadurch hat das Projekt auch einen sehr hohen [Woman Acceptance Factor](https://de.m.wikipedia.org/wiki/Woman_acceptance_factor) erzielt.
+
+## Ausblick
+
+Es gibt noch einige Möglichkeiten, das Projekt über den kommenden Winter zu verbessern und zu erweitern. Wir denken da an:
+
+- Temperatursensor direkt am Solarkreislauf, um zu prüfen, ob die Heizung im Solar- oder Heizmodus ist
+- Outdoor-Sensor für Umgebungstemperatur und Wassertemperatur mit Versorgung über Solarzellen
+- Die Regelsteuerung direkt im ESP-Code auf dem Pool Controller (nur noch Update der Konfiguration und Monitoring über MQTT)
+- Mehr Sicherheit durch Verschlüsselung der MQTT-Kommunikation
+- Messung der Wasserqualität (pH, Chlor) durch zusätzliche Sensoren
+- Einbeziehen der Wettervorhersage, um den Pufferspeicher noch optimaler einzuteilen
+
+Wir freuen uns über Nachbauten, inspirierte Projekte und Vorschläge für weitere Verbesserungen. Gerne auch als Pull-Requests auf GitHub.

--- a/content/blog/pool-controller-2-4.de.md
+++ b/content/blog/pool-controller-2-4.de.md
@@ -1,0 +1,92 @@
+---
+title: "Der Pool-Controller (2/4)"
+date: 2018-10-22
+authors:
+  - name: "Stephan Strittmatter"
+    link: https://github.com/stritti
+    image: https://github.com/stritti.png
+tags:
+  - "Development"
+  - "Deutsch"
+  - "ESP32"
+---
+
+Im [vorangegangenen Artikel]({{< relref "smarte-steuerung-1-4" >}}) haben wir einen Überblick über das Projekt des smart gesteuerten Pools gegeben. In diesem zweiten Teil werden wir auf das Herzstück, den Controller, eingehen. Dieser basiert auf einem ESP32, könnte aber mit wenigen Modifikationen auch mit einem ESP8266 umgesetzt werden.
+
+## Aufgabe des Pool-Controllers
+
+Der Controller wird die zentrale Steuerung übernehmen. Er misst zyklisch die Temperaturen des Poolwassers und des Wärmespeichers der Solaranlage. Zudem wird er die Pumpen (Filter und Heizung) schalten. Der ESP ist also sowohl Sensor als auch Aktor. Der Datenaustausch erfolgt über WLAN mittels MQTT.
+
+### Temperaturen messen
+
+Das Messen der Temperatur ist meist der Einstieg in die Programmierung von IoT-Sensoren. Es gibt diverse Projektbeispiele dazu. Dabei kommen oft die Temperatursensoren DHT11 oder der genauere DHT22 zum Einsatz. Da die Temperatursensoren im Projekt jedoch verteilt extern platziert werden müssen, verwenden wir den wasserdichten Sensor [DS18B20](https://www.az-delivery.de/collections/temperatursensoren/products/2xds18b20wasserdicht?ls=de). Einen der beiden Sensoren zur Messung der Temperatur des Poolwassers, der andere zur Messung der Temperatur im Pufferspeicher.
+
+Die gemessenen Temperaturen werden mittels Timer alle 60 Sekunden ausgelesen und per MQTT als Nachricht veröffentlicht. Der Intervall ist ein Kompromiss zwischen der Trägheit der Erwärmung des Wassers und dem Debugging des Programms. Vermutlich würden auch Werte alle 5 Minuten ausreichen, doch auch die Integration in OpenHAB macht der minütliche Takt später wesentlich einfacher.
+
+### Funksteckdosen steuern
+
+Da wir in dem Projekt nicht direkt mit 230 Volt Wechselspannung hantieren möchten, schalten wir die Pumpen über Funksteckdosen. Bei den Funksteckdosen gibt es einige, die man über ESPs mit einem [433 MHz Funksender](https://www.az-delivery.de/products/433-mhz-modul?ls=de) steuern kann. Eine Liste der kompatiblen Funksteckdosen findet sich im [Wiki](https://github.com/sui77/rc-switch/wiki/List_KnownDevices) der verwendeten Bibliothek.
+
+## Aufbau der Schaltung
+
+Die Datenpins am ESP32 sind wie folgt belegt:
+
+```cpp
+#define PIN_DS_SOLAR 16   // Temp-Sensor Solar
+#define PIN_DS_POOL 17    // Temp-Sensor Pool
+#define PIN_RSSWITCH 18   // für 433MHz Sender
+```
+
+## Quellcode des Projektes
+
+Für das Projekt verwenden wir die Entwicklungsumgebung [Platform.io IDE](https://platformio.org/platformio-ide). Damit legen wir ein Projekt für das Board `esp32dev` an.
+
+Der komplette Quellcode des Projektes ist im GitHub-Repository des Autors zu finden: [https://github.com/stritti/smart-swimming-pool](https://github.com/stritti/smart-swimming-pool).
+
+## Verwendete Bibliotheken
+
+In diesem Projekt ist es uns wichtig, auf bewährte Softwarekomponenten zurückzugreifen und möglichst viel über vorhandene Bibliotheken zu lösen. Aus diesem Grund kommen folgende Libs zum Einsatz:
+
+- **rc-switch**: Steuerung der Funksteckdosen
+- **OneWire**: Unterstützung für I2C-Sensoren
+- **DallasTemperature**: Auslesen der Temperatur der Sensoren
+- **PubSubClient**: MQTT-Nachrichten empfangen und versenden
+- **RemoteDebug**: Debugging über Telnet
+- **ESPBASE**: Template für IoT-Projekte
+
+Diese Bibliotheken sind in der Konfiguration von Platform.io (`platformio.ini`) hinterlegt und werden beim Kompilieren automatisch aus dem Internet geladen und eingebunden.
+
+Das Programm für den Pool-Controller basiert auf ESPBASE, das wie im vorangegangenen Artikel geschrieben einige Setup-Funktionen bereitstellt. Am Anfang des Codes werden dazu einige Variablen angelegt und die Defines für die Pinbelegung definiert.
+
+Neben den beiden Funktionen `setup()` und `loop()` sind einige weitere Funktionen implementiert. Im Wesentlichen geht es hierbei um das Empfangen und Senden von MQTT-Nachrichten und das entsprechende Umsetzen der Nachrichten. Zudem ist ein Timer implementiert, der zyklisch die Temperatursensoren ausliest und per MQTT-Nachrichten publiziert.
+
+## Die Details
+
+1. In der `loop`-Funktion wird die WLAN-Verbindung immer wieder geprüft und gegebenenfalls wieder hergestellt. Das war ein tückisches Problem: der ESP hat immer mal wieder die WLAN-Verbindung verloren und ohne den Reconnect konnte er keine Daten mehr versenden.
+2. Die Funktion `publish` dient zum Versenden der MQTT-Nachrichten. So werden die Daten von einem Neustart und von den Temperaturmessungen als JSON-Nachrichten publiziert.
+3. Der Timer für das Versenden der Temperaturen ist aufgeteilt. Grund ist, dass die eigentlichen Timer-Methoden möglichst kurz sein müssen. In der Implementierung ruft der Timer die Funktion `onTimer` auf, welche nur den volatilen `interruptCounter` inkrementiert. In der `loop`-Funktion wird dieser überprüft und die eigentliche `onTemperature`-Funktion ausgelöst. In dieser Methode wird auch die interne Temperatur des ESP ausgelesen und publiziert.
+4. Die Funktion `onMQTTCallback` wird aufgerufen, wenn eine Nachricht an ein Topic, das mit `/pool/switch/` beginnt, gesendet wurde. Die Nachricht enthält die Information der Funksteckdose, ob diese ein- bzw. ausgeschaltet werden soll. Das Topic wird dabei weiter unterteilt in die Gruppe und die Gerätekodierung. Das heißt, die Kodierung der DIP-Schalter der Steckdose transformiert in 0 und 1. Dadurch ist diese Lösung flexibel auch an anderer Stelle nutzbar.
+
+Der Quellcode des Pool-Controllers findet man direkt komplett in folgender Datei: [Pool-Controller/src/pool-control.ino](https://github.com/stritti/smart-swimming-pool/blob/master/Pool-Controller/src/pool-control.ino)
+
+## Testing
+
+Ist die Schaltung aufgebaut und das Projekt auf den ESP geladen, können wir bereits testen. Der ESP wird ein WLAN als Access Point öffnen, da standardmäßig kein WLAN eingerichtet ist. Wenn man sich mit dem Pool-Controller mit dem Smartphone verbindet, kann man das richtige WLAN einrichten. Danach startet der Microcontroller automatisch neu und versucht, sich mit dem angegebenen WLAN zu verbinden.
+
+Ist alles richtig eingerichtet, so sollte bereits beim Start des ESP eine Statusnachricht via MQTT publiziert werden. Man kann mit folgendem Kommando auf dem Raspberry alle Nachrichten tracken:
+
+```bash
+mosquitto_sub -h localhost -v -t /#
+```
+
+Eventuell muss im Quellcode die IP-Adresse des MQTT-Servers angepasst werden. Danach sollten im Minutenzyklus die Temperaturen auf dem Raspberry ausgegeben werden.
+
+In die andere Richtung können wir die Funksteckdosen schalten, indem wir eine passende Nachricht versenden. Dabei setzt sich das Topic aus `/pool/switch/<group>/<device>` zusammen. `Group` und `Device` sind die DIP-Schalter der Steckdose als 0 und 1. Als Nachricht wird `ON` bzw. `OFF` gesendet.
+
+## Wie geht es weiter?
+
+Damit sind die Grundlagen geschaffen: wir können die Temperaturen auslesen und wir können Steckdosen schalten.
+
+Im folgenden Artikel verbinden wir den Pool-Controller mit der Smart Home Lösung openHAB und machen den Pool durch Regeln richtig smart.
+
+- [Weiter zu Teil 3: Swimmingpool und OpenHAB (3/4)]({{< relref "swimmingpool-openhab-3-4" >}})

--- a/content/blog/projekt-smart-swimmingpool-einleitung.de.md
+++ b/content/blog/projekt-smart-swimmingpool-einleitung.de.md
@@ -1,0 +1,32 @@
+---
+title: "Projekt Smart Swimmingpool — Einleitung"
+date: 2018-10-17
+authors:
+  - name: "Stephan Strittmatter"
+    link: https://github.com/stritti
+    image: https://github.com/stritti.png
+tags:
+  - "Development"
+  - "Deutsch"
+---
+
+In den folgenden vier Blogposts werde ich Schritt für Schritt beschreiben, wie man einen Swimmingpool mittels selbstgebauten IoT-Modulen steuern kann. Die Kosten der benötigten elektronischen Bauteile liegen dabei unter 100 Euro.
+
+- **Eingangsartikel**: Smart Swimming Pool mit der Problemstellung und den Anforderungen, notwendige Hardware sowie das Ziel der Serie
+- **Pool-Controller**: Der Controller, der Temperaturen misst und periodisch via MQTT versendet sowie über MQTT Steckdosen (433MHz) schalten kann, MQTT-Server auf Raspberry einrichten
+- **OpenHAB**: Anbindung des Controllers, Darstellung der Messdaten, Steuern der Steckdosen
+- **Der Smart Pool**: Die smarte Steuerung durch OpenHAB-Regeln, Fazit & Ausblick
+
+## Autor
+
+**Stephan Strittmatter** ist als Talent Scout in einem IT Beratungshaus tätig und bringt jungen Nachwuchskräften die Softwareentwicklung näher. Vor wenigen Monaten hatte er so auch über den Raspberry Pi und dem micro:bit schlussendlich Berührungspunkte mit den ESP-Controllern. Diese haben ihm den Kindheitstraum ermöglicht, endlich Hardware und Software einfach zu verbinden. Der private Pool war deshalb ein willkommenes Projekt, um IoT, Smart Home und Forschertrieb zu vereinen.
+
+- Twitter/X: @\_stritti\_
+- GitHub: [https://github.com/stritti](https://github.com/stritti)
+
+### Weiter zur Artikelserie
+
+- [Smarte Steuerung für den Swimmingpool (1/4)]({{< relref "smarte-steuerung-1-4" >}})
+- [Der Pool-Controller (2/4)]({{< relref "pool-controller-2-4" >}})
+- [Swimmingpool und OpenHAB (3/4)]({{< relref "swimmingpool-openhab-3-4" >}})
+- [Der smarte Pool (4/4)]({{< relref "der-smarte-pool-4-4" >}})

--- a/content/blog/smart-swimming-pool-project.md
+++ b/content/blog/smart-swimming-pool-project.md
@@ -1,0 +1,273 @@
+---
+title: "Project Smart Swimming Pool"
+date: 2018-12-01
+authors:
+  - name: "Stephan Strittmatter"
+    link: https://github.com/stritti
+    image: https://github.com/stritti.png
+tags:
+  - "Development"
+---
+
+Smart Control for the Swimming Pool — In the following four series of articles, we will describe step by step, how to control a swimming pool by means of self-built IoT modules. The cost of the required electronic components are less than 100 euros.
+
+## Goal
+
+1. Control the pool and its temperature via a solar system with open source and low-cost electronic components
+2. Access via WiFi and Internet
+3. Flexible expandability
+
+## Starting Position
+
+We have a swimming pool, which is cleaned by a sand filter system. This sand filter system has to filter the pool water daily for a certain amount of time.
+
+In addition, we have a thermal solar system, which is designed to support heating and hot water. As this produces too much heat in the summer, it was natural to use this heat in the summer to heat the pool. This is easily possible via additional connections to the heat storage: a circulation pump directs the warm solar water through a [heat exchanger](https://pooldoktor.at/waermetauscher-pool.html), which heats the pool water.
+
+The pump for the water circulation is switched by a timer. The pump for heating is switched on manually as required behind the timer. Of course this is stupid, if one has integrated the solar system in the morning and changes the weather in the course of the day: In the evening, the water for showering and cooking is cold, since all the energy has flowed into the pool. That should change this year!
+
+## Requirements
+
+From this situation arose the desire to control the pool smart. What are the basic requirements?
+
+1. Sensors for heat accumulators and pool water
+2. Switching possibility for the pumps
+3. Control system
+
+All this is easy to implement with an ESP micro controller and a Raspberry Pi. The individual solutions are also available in the web. The pitfalls, however, are in the detail of the combination.
+
+## Required Hardware
+
+The following parts and components needed for the pool controller:
+
+- 1× ESP32 NodeMCU
+- 2× temperature sensors DS18B20
+- 1× 433MHz radio module
+- 2× 4.7kΩ resistors
+- 2× radio sockets
+- various plug wires
+- board or breadboard
+- power supply
+
+For the openHAB server:
+
+- 1× Raspberry Pi
+
+## Basis for the Pool Controller
+
+Let's start with the heart of the game, the pool controller. In order not to reinvent the wheel again and again, I decided to set up the project on a basis. I found these in the [ESPBASE](https://github.com/Pedroalbuquerque/ESPBASE) project. As a template, the project offers support for setting up WiFi via an access point and some other functions that I no longer have to take care of myself. In his project, the developer created an [example](https://github.com/Pedroalbuquerque/ESPBASE/tree/master/Examples/WiFi_CFG_OTA_Telnet) for the use of ESPBASE. We will build the controller on this basis.
+
+## Smart Home Integration
+
+Finally, the pool controller is integrated into the open source home automation system [openHAB](https://www.openhab.org/) and thus also offers access via apps on the smartphone.
+
+For the integration we need a protocol for the message exchange. We use MQTT for this. MQTT is a lightweight messaging protocol that is widely used in IoT (Internet of Things).
+
+For the communication of the pool controller we will need an MQTT broker. For this purpose we have installed the broker [Mosquitto](https://mosquitto.org/) on the Raspberry Pi (since openHAB 2.4 there will be inbuild MQTT-server, too).
+
+### Installing and Testing MQTT Server Mosquitto
+
+We install the MQTT broker Mosquitto on the Raspberry Pi:
+
+```bash
+sudo apt-get update
+sudo apt-get upgrade
+sudo apt-get install mosquitto mosquitto-clients
+```
+
+We open a Subscriber on the topic "/topic" which waiting for messages:
+
+```bash
+mosquitto_sub -h localhost -v -t /topic
+```
+
+The topic is like listening to a radio frequency. Different data such as temperatures can be transmitted in different channels.
+
+We can test this directly on the Raspberry with the following command, which publishes a message in another console window:
+
+```bash
+mosquitto_pub -h localhost -t /topic -m "Hello smart Pool"
+```
+
+There are also clients for the smartphone or the Windows PC to receive or send the MQTT messages.
+
+## Task of the Pool Controller
+
+The pool controller will take over the central control. It cyclically measures the temperatures of the pool water and the heat storage of the solar system. He will also switch the pumps (filter and heater). The ESP is thus both sensor and actuator. The data exchange takes place via WiFi using MQTT.
+
+### Temperature Measurement
+
+Measuring the temperature is usually the entry into the programming of IoT sensors. There are various project examples. Often the temperature sensors [DHT11](https://amzn.to/2D28cJs) or the more accurate [DHT22](https://amzn.to/2Bf1e41) are used. However, since the temperature sensors in the project have to be distributed externally, we use the waterproof sensor [DS18B20](https://amzn.to/2HKjSXc). One of the two sensors for measuring the temperature of the pool water, the other for measuring the temperature in the buffer tank.
+
+The measured temperatures are read by timer every 60 seconds and published by MQTT as a message. The interval is a compromise between the inertia of heating the water and debugging the program. Probably values would be sufficient every 5 minutes, but also the integration in openHAB makes the minute clock later much easier.
+
+### Controlling Radio-controlled Sockets
+
+Since I do not want to handle 230 volts AC directly in the project, I switch the pumps via radio-controlled sockets. There are some radio sockets that can be controlled via ESPs with a 433 MHz radio transmitter.
+
+## Layout of the Circuit
+
+The data pins on the ESP32 are assigned as follows:
+
+```cpp
+#define PIN_DS_SOLAR 16   // temp sensor solar
+#define PIN_DS_POOL 17    // temp sensor pool
+#define PIN_RSSWITCH 18   // for 433MHz transmitter
+```
+
+## Source Code of the Project
+
+For the project we use the development environment [Platform.io IDE](https://platformio.org/platformio-ide). With this we create a project for the board `esp32dev`.
+
+> The full source code of the project can be found in the GitHub repository: [https://github.com/stritti/smart-swimming-pool](https://github.com/stritti/smart-swimming-pool).
+
+### Libraries Used
+
+In this project, it is important to use proven software components and to solve as much as possible about existing libraries. For this reason, the following libs are used:
+
+- **rc-switch**: Control of the radio-controlled sockets
+- **OneWire**: Support for I2C sensors
+- **DallasTemperature**: Reading out the temperature of the sensors
+- **PubSubClient**: Receiving and sending MQTT messages
+- **RemoteDebug**: Debugging via Telnet
+- **ESPBASE**: Template for IoT projects
+
+These libraries are stored in the configuration of Platform.io (`platformio.ini`) and are automatically loaded and integrated from the internet during compilation.
+
+### The Details
+
+1. In the `loop` function, the WiFi connection is repeatedly checked and, if necessary, restored. That was a treacherous problem: the ESP has repeatedly lost the wireless connection and without the reconnect it could no longer send any data.
+2. The function `publish` is used to send the MQTT messages. Thus the data of a restart and the temperature measurement are published as JSON messages.
+3. The timer for sending the temperatures is split. The reason is that the actual timer methods have to be as short as possible. In the implementation, the timer calls the `onTimer` function, which only increments the volatile `interruptCounter`. The `loop` function checks this and the actual `onTemperature` function is triggered. This method also reads and publishes the internal temperature of the ESP.
+4. The function `onMQTTCallback` is called when a message is sent to a topic starting with `/pool/switch/`. The message contains the information of the radio-controlled socket whether it should be switched on or off. The topic is further subdivided into the group and the device coding. This means that the coding of the DIP switches of the socket is transformed into 0 and 1. As a result, this solution can also be used flexibly elsewhere.
+
+The source code of the pool controller can be found directly in the following file: [Pool-Controller/src/pool-control.ino](https://github.com/stritti/smart-swimming-pool/blob/master/Pool-Controller/src/pool-control.ino)
+
+## Testing
+
+Once the circuit has been set up and the project loaded onto the ESP, we can already test it. The ESP will open a WiFi as an access point because there is no WiFi setup by default. If you connect with the pool controller with the smartphone, you can set up the right wireless. Thereafter, the micro controller restarts automatically and tries to connect to the specified WiFi.
+
+If everything is set up correctly, a status message via MQTT should be published already at the start of the ESP. You can do this with the following command on the Raspberry track all messages:
+
+```bash
+mosquitto_sub -h localhost -v -t /#
+```
+
+It may be necessary to change the IP address of the MQTT server in the source code. Thereafter, the temperatures should be shown on the Raspberry in a minute cycle.
+
+In the other direction we can switch the radio sockets by sending a suitable message. The topic consists of `/pool/switch/<group>/<device>`. `Group` and `Device` are the dip switches of the socket as 0 and 1. The message "ON" or "OFF" is sent.
+
+## Swimming Pool and OpenHAB
+
+After we created the controller for the pool control, we will now connect it via WiFi with OpenHAB and implement the rules for the smart control.
+
+### Installation of OpenHAB
+
+OpenHAB is a "Home Automation Broker", which is a Smart Home Server software that can be installed on a Raspberry Pi. There is a very good [documentation](https://www.openhab.org/docs/installation/openhabian.html).
+
+I assume here that a basic installation of openHAB already exists.
+
+We now need to add some addons to the installation under certain circumstances. This is possible via the "[Paper UI](https://www.openhab.org/docs/configuration/paperui.html)" interface under "Add-ons".
+
+For the integration of the pool control, we need the following add-ons:
+
+- MQTT Binding
+- openHAB Cloud Connector (optional for internet access via smartphone apps)
+- RRD4j Persistence
+- JSONPath Transformation
+- Basic UI
+
+### Configuration
+
+The configuration files that we create now are usually located in the path on the Raspberry `/etc/openhab2`. The corresponding structure with the files are stored in the GitHub repository.
+
+### Connect MQTT Broker
+
+The configuration for connecting the Mosquitto service can be found in the file `services/mqtt.cfg`. The host name and the port are configured there. In our case, openHAB and Mosquitto run on the same Raspberry.
+
+### Sitemap with the Items
+
+First we have to define the objects (items) in openHAB so that we can control and evaluate them on the sitemap.
+
+### pool.items
+
+The measuring and control points are defined in the file [`pool.items`](https://github.com/stritti/smart-swimming-pool/blob/master/OpenHAB/items/2-pool.items). There, for example, the links between the MQTT topics and the items are made. So there are the items for the temperatures, which receive the data from MQTT and the items send the messages to switch the pumps. The greater or lesser character in the configuration indicates the direction of the messages.
+
+## The Smart Swimming Pool
+
+Now it's all about making the controller really smart: the regulation is automatic and can be adjusted via WLAN or Internet.
+
+### Rule Control of Pool
+
+I have implemented three modes for the heating of the pool:
+
+### Mode: Auto
+
+The fully automatic mode switches the filter pump time-controlled and automatically heats the pool water up to a maximum temperature. However, this only as long as the minimum temperature in the heat storage is not exceeded.
+
+### Mode: Boost
+
+Similar to the "Auto" mode, but without considering the minimum temperature in the heat accumulator.
+
+### Mode: Manual
+
+The pumps are manually switched on and off via the app. Regardless of rules and thresholds.
+
+### The Limit Values
+
+The following three parameters are required to control the temperature of the pool:
+
+- **Maximum pool temperature**: How warm should the pool be?
+- **Minimum heat storage temperature**: What temperature must the water in the storage tank at least have, that the pool can be co-heated?
+- **Hysteresis**: How big should the temperature deviation be before the min/max rules affect?
+
+### The Smart Heart: pool.rules
+
+The rules in the `pool.rules` are the rules of openHAB. These rules use the configuration values that you can set in the settings.
+
+The values of the temperature sensors are compared here and the radio sockets are then controlled on the basis of the hysteresis. Hysteresis is necessary so that the pumps are not constantly switched on and off at very low temperature differences. A value of 0.5 Kelvin has proved to be completely sufficient.
+
+The rules are divided and thus operate the individual operating modes.
+
+### Add-On: Display Module
+
+To monitor the temperatures even without an app, we put a small monitoring application in an old screw box. This module was based on the LCD display, which was also featured in a [blog article](https://www.az-delivery.de/blogs/azdelivery-blog-fur-arduino-und-raspberry-pi/lcd-display-16-x-2-produkteinfuhrung?ls=de).
+
+This pool monitor is based on an ESP8266 and a LCD display 16×2. The ESP receives the temperature values — also via MQTT — and updates the display.
+
+The source code for this is also located in the code repository and was derived from the pool controller.
+
+The case is an old screw box that has been padded with some filler material. Something tricky was the hole for the micro USB plug. Maybe next year this box will be upgraded and equipped with a solar cell. Then this can also be installed outside near the pool.
+
+## Open Source
+
+The aim from the beginning was to create a project based on open source. So, of course, again an open source project was created.
+
+The entire project is available on GitHub:
+
+[https://github.com/stritti/smart-swimming-pool](https://github.com/stritti/smart-swimming-pool)
+
+## Conclusion
+
+The pool controller has been in use since May and after a few improvements has worked reliably over the complete summer.
+
+The main problem was actually the missing check, whether the WiFi connection still exists. We always thought we had a leak in the code somewhere, but occasionally the ESP controller just lost the connection over the WiFi. Now the controller runs reliably, provides data and controls the pumps.
+
+Since this year, so there is a nice warm pool and still always enough hot water in the home. A project with clear added value in terms of comfort with relatively little financial input.
+
+## Outlook
+
+There are still a few ways to improve and expand the project over the coming winter. We think of:
+
+- Temperature sensor directly on the solar circuit to check whether the heater is in solar or heating mode
+- Outdoor sensor for ambient temperature and water temperature with solar cell supply
+- The control directly in the ESP code on the pool controller (only update the configuration and monitoring via MQTT)
+- Greater security through encryption of MQTT communication
+- Measurement of water quality (pH, chlorine) by additional sensors
+- Inclusion of weather forecast to better allocate the buffer memory
+- Switch inbuild MQTT service of openHAB 2.4+ (and use Homie 3.0 conform MQTT messages)
+
+I am looking forward to replicas, inspired projects and suggestions for further improvements. Also available as pull requests on GitHub.
+
+## Author
+
+**Stephan Strittmatter** is talent scout at an IT consulting company and brings software development closer to young professionals. A few months ago he finally had contact points with the ESP controllers via the Raspberry Pi and the BBC micro:bit. They made his childhood dream possible, to finally connect hardware and software easily. The private pool was therefore a welcome project to combine IoT, Smart Home and research drive.

--- a/content/blog/smarte-steuerung-1-4.de.md
+++ b/content/blog/smarte-steuerung-1-4.de.md
@@ -1,0 +1,104 @@
+---
+title: "Smarte Steuerung für den Swimmingpool (1/4)"
+date: 2018-10-19
+authors:
+  - name: "Stephan Strittmatter"
+    link: https://github.com/stritti
+    image: https://github.com/stritti.png
+tags:
+  - "Development"
+  - "Deutsch"
+---
+
+In der folgenden vierteiligen Artikelserie werden wir Schritt für Schritt beschreiben, wie man einen Swimmingpool mittels selbstgebauten IoT-Modulen steuern kann. Die Kosten der benötigten elektronischen Bauteile liegen dabei unter 100 Euro.
+
+## Ziel
+
+1. Mit Open Source und preiswerten Elektronikkomponenten den Pool und seine Temperatur über eine Solaranlage steuern
+2. Zugriff über WLAN und Internet
+3. Flexible Erweiterbarkeit
+
+## Ausgangslage
+
+Wir haben einen Swimmingpool, der über eine Sandfilteranlage gereinigt wird. Diese Sandfilteranlage muss täglich für eine gewisse Zeit das Poolwasser filtern.
+
+Zusätzlich haben wir eine thermische Solaranlage, welche zur Unterstützung von Heizung und Warmwasser ausgelegt ist. Da diese im Sommer viel zu viel Wärme produziert, lag die Überlegung nahe, diese Wärme im Sommer zur Beheizung des Pools zu nutzen. Dies ist über zusätzliche Anschlüsse am Wärmespeicher ohne weiteres möglich: eine Umwälzpumpe leitet das warme Solarwasser durch einen [Wärmetauscher](https://pooldoktor.at/waermetauscher-pool.html), der das Poolwasser erwärmt.
+
+Die Pumpe für die Wasserumwälzung wird über eine Zeitschaltuhr geschaltet. Die Pumpe zur Erwärmung wird manuell nach Bedarf hinter der Zeitschaltuhr mit zugeschaltet. Das ist natürlich doof, wenn man morgens die Solaranlage mit eingebunden hat und im Laufe des Tages das Wetter umschlägt: Am Abend ist das Wasser zum Duschen und Kochen kalt, da alle Energie in den Pool geflossen ist. Das sollte sich dieses Jahr ändern!
+
+## Anforderungen
+
+Aus dieser Situation entstand der Wunsch, den Pool smart zu steuern. Was wird grundsätzlich dazu benötigt?
+
+1. Sensoren für Wärmespeicher und Poolwasser
+2. Schaltmöglichkeit für die Pumpen
+3. Eine Regelsteuerung
+
+All das ist mit einem ESP-Microcontroller und einem Raspberry Pi einfach umzusetzen. Die einzelnen Lösungen gibt es für sich genommen auch hier im Blog:
+
+- [Thermometer mit OLED Display](https://www.az-delivery.de/blogs/azdelivery-blog-fur-arduino-und-raspberry-pi/thermometer-mit-oled-display?ls=de)
+- [Raspberry Pi mit OpenHab](https://www.az-delivery.de/blogs/azdelivery-blog-fur-arduino-und-raspberry-pi/raspberry-mit-openhab2)
+- [Was funkt denn da? 433Mhz Module](https://www.az-delivery.de/blogs/azdelivery-blog-fur-arduino-und-raspberry-pi/was-funkt-denn-da-433mhz-module-prufen?ls=de)
+
+Die Tücken stecken jedoch im Detail der Kombination. Das werden wir in den folgenden Artikeln sehen.
+
+## Benötigte Hardware
+
+Folgende Bauteile und Komponenten werden für den Pool-Controller benötigt:
+
+- 1× ESP32 Development Board
+- 2× Temperatursensoren DS18B20
+- 1× 433MHz Funkmodul
+- 2× 4.7kΩ Widerstände
+- 2× Funksteckdosen
+- diverse Steckdrähte
+- Platine bzw. Breadboard
+- Stromversorgung
+
+Für den OpenHAB-Server:
+
+- 1× Raspberry Pi als Serverzentrale
+
+## Basis für den Pool-Controller
+
+Beginnen werden wir mit dem Herzstück, dem Pool-Controller. Um das Rad nicht immer wieder neu zu erfinden, haben wir uns entschieden, für das Projekt auf einer Basis aufzusetzen. Diese haben wir in dem Projekt [ESPBASE](https://github.com/Pedroalbuquerque/ESPBASE) gefunden. Das Projekt bietet als Template Unterstützung für die Einrichtung von WLAN über einen Accesspoint und einige andere Funktionen, um die wir uns nicht mehr selbst kümmern müssen. Der Entwickler hat in seinem Projekt ein [Beispiel](https://github.com/Pedroalbuquerque/ESPBASE/tree/master/Examples/WiFi_CFG_OTA_Telnet) für die Nutzung von ESPBASE erstellt. Auf dieser Basis werden wir den Controller aufbauen.
+
+## Smart Home Integration
+
+Schlussendlich wird der Pool-Controller in die Open Source Homeautomation [openHAB](https://www.openhab.org/) integriert und bietet damit auch Zugriff über Apps auf dem Smartphone.
+
+Für die Integration benötigen wir ein Protokoll für den Nachrichtenaustausch. Wir nutzen dafür MQTT. MQTT ist ein leichtgewichtiges Nachrichtenprotokoll, das sehr häufig im Bereich IoT (Internet der Dinge) genutzt wird.
+
+Für die Kommunikation des Pool-Controllers werden wir einen MQTT-Broker benötigen. Dazu haben wir auf dem Raspberry Pi den Broker [Mosquitto](https://mosquitto.org/) installiert (seit openHAB 2.4 gibt es auch einen integrierten MQTT-Server).
+
+### MQTT Server Mosquitto installieren und testen
+
+Den MQTT-Broker Mosquitto installieren wir auf dem Raspberry Pi:
+
+```bash
+sudo apt-get update
+sudo apt-get upgrade
+sudo apt-get install mosquitto mosquitto-clients
+```
+
+Wir öffnen einen Subscriber auf dem Topic `/topic`, welcher auf Nachrichten wartet:
+
+```bash
+mosquitto_sub -h localhost -v -t /topic
+```
+
+Das Topic ist wie eine Radiofrequenz, auf der zugehört wird. So können in verschiedenen Kanälen unterschiedliche Daten wie z.B. die Temperaturen gesendet werden.
+
+Testen können wir dies direkt auf dem Raspberry mit folgendem Kommando, welches in einem weiteren Konsolenfenster eine Nachricht publiziert:
+
+```bash
+mosquitto_pub -h localhost -t /topic -m "Hallo smart Pool"
+```
+
+Es gibt auch Clients für das Smartphone oder den Windows-PC, um die MQTT-Nachrichten zu empfangen oder zu versenden.
+
+## Wie geht es weiter?
+
+Nun sind die ersten Voraussetzungen geschaffen. Im folgenden Artikel werden wir den Pool-Controller auf Basis des ESP32 vorstellen, der seine Daten über den eingerichteten MQTT-Broker bereitstellt.
+
+- [Weiter zu Teil 2: Der Pool-Controller (2/4)]({{< relref "pool-controller-2-4" >}})

--- a/content/blog/swimmingpool-openhab-3-4.de.md
+++ b/content/blog/swimmingpool-openhab-3-4.de.md
@@ -1,0 +1,66 @@
+---
+title: "Swimmingpool und OpenHAB (3/4)"
+date: 2018-10-23
+authors:
+  - name: "Stephan Strittmatter"
+    link: https://github.com/stritti
+    image: https://github.com/stritti.png
+tags:
+  - "Development"
+  - "Deutsch"
+  - "openHAB"
+---
+
+Nachdem wir im [vorangegangenen Blogartikel]({{< relref "pool-controller-2-4" >}}) den Controller für die Poolsteuerung erstellt haben, werden wir diesen nun über das WLAN mit OpenHAB verbinden und dort die Regeln für die smarte Steuerung implementieren.
+
+## Installation von OpenHAB
+
+OpenHAB ist ein "Home Automation Broker", also eine Smart Home Server Software. Diese kann auf einem Raspberry Pi installiert werden. Wir gehen hier davon aus, dass schon eine Grundinstallation von OpenHAB besteht.
+
+Wir müssen nun unter Umständen noch einige Addons der Installation hinzufügen. Dies ist über die Oberfläche "[Paper UI](https://www.openhab.org/docs/configuration/paperui.html)" im Unterpunkt "Add-ons" möglich.
+
+Für die Integration der Poolsteuerung benötigen wir folgende Add-ons:
+
+- MQTT Binding
+- openHAB Cloud Connector (optional für Internetzugriff über die Smartphone Apps)
+- RRD4j Persistence
+- JSONPath Transformation
+- Basic UI
+
+## Konfiguration
+
+Die Konfigurationsdateien, die wir nun erstellen, liegen auf dem Raspberry normalerweise in dem Pfad `/etc/openhab2`. Die entsprechende Struktur mit den Dateien sind im GitHub-Repository hinterlegt.
+
+### MQTT-Broker anbinden
+
+Die Konfiguration für die Anbindung des Mosquitto Dienstes befindet sich in der Datei `services/mqtt.cfg`. Dort wird der Hostname und der Port konfiguriert. In unserem Fall laufen openHAB und Mosquitto auf demselben Raspberry.
+
+### Sitemap mit den Items
+
+Zunächst müssen wir nun in OpenHAB die Objekte (Items) definieren, damit wir diese auf der Sitemap steuern und auswerten können.
+
+### pool.items
+
+In der Datei [`pool.items`](https://github.com/stritti/smart-swimming-pool/blob/master/OpenHAB/items/2-pool.items) werden die Mess- und Steuerpunkte festgelegt. Dort werden zum Beispiel die Verknüpfungen der MQTT-Topics mit den Items vorgenommen. So gibt es die Items für die Temperaturen, welche die Daten von MQTT entgegennehmen und die Items, die Nachrichten versenden, um die Pumpen zu schalten. Das Größer- bzw. Kleiner-Zeichen in der Konfiguration gibt jeweils die Richtung der Nachrichten an:
+
+```java
+Number  Sensor_Solar_Temperature "Solar"
+(gPool, gTemperature, Chart_Pool_Temperature)
+["CurrentTemperature", "object:solar"] {
+  mqtt="<[mqtt:/sensor/solar/temperature:state:JSONPATH($.value)]"
+}
+```
+
+Für Chart-Grafiken und die Integration in Alexa sind noch einige weitere Konfigurationselemente integriert. So kann zum Beispiel über die Einstellungen der Zeitraum der Charts festgelegt werden.
+
+Die Charts werden genutzt, um die Temperaturverläufe und die Schaltzeiten zu visualisieren. Damit die Charts richtig funktionieren, benötigen diese Daten im Abstand von maximal einer Minute. Da passt also unser Timer im Pool-Controller bestens.
+
+Die Messdaten werden in einer RRD4j-Datenbank gespeichert. Dazu existiert ebenfalls eine Konfiguration im Repository. Da wir die Daten nicht für Langzeitauswertungen benötigen, reicht diese interne Datenbank von openHAB völlig aus.
+
+## Wie geht es weiter?
+
+Nun haben wir die Sitemap mit den Temperaturwerten und den Schaltmöglichkeiten für die beiden Pumpen.
+
+Im abschließenden vierten Artikel werden wir auf die Regeln für die automatisierte Steuerung des Pools eingehen.
+
+- [Weiter zu Teil 4: Der smarte Pool (4/4)]({{< relref "der-smarte-pool-4-4" >}})

--- a/content/docs/publications.de.md
+++ b/content/docs/publications.de.md
@@ -1,9 +1,25 @@
 ---
 title: Publikationen
-weight: 20
+weight: 80
 tags: ["docs", "publication"]
 ---
 
-- [AZ Delivery: Projekt Smart Swimmingpool](https://www.az-delivery.de/blogs/azdelivery-blog-fur-arduino-und-raspberry-pi/projekt-smart-swimmingpool-einleitung), _Oktober 2018_
+Auch verfügbar als [Blog-Beiträge](/blog/) auf dieser Seite.
+
+- [Projekt Smart Swimmingpool](https://www.az-delivery.de/blogs/azdelivery-blog-fur-arduino-und-raspberry-pi/projekt-smart-swimmingpool-einleitung), _Oktober 2018_
 
   Vierteilige Blog-Reihe zur Version 1 des Smart Pool Controllers.
+
+  📄 [Hier auf der Seite lesen]({{< relref "/blog/projekt-smart-swimmingpool-einleitung" >}})
+
+  - [Smarte Steuerung für den Swimmingpool (1/4)]({{< relref "/blog/smarte-steuerung-1-4" >}})
+  - [Der Pool-Controller (2/4)]({{< relref "/blog/pool-controller-2-4" >}})
+  - [Swimmingpool und OpenHAB (3/4)]({{< relref "/blog/swimmingpool-openhab-3-4" >}})
+  - [Der smarte Pool (4/4)]({{< relref "/blog/der-smarte-pool-4-4" >}})
+
+- [Project Smart Swimming Pool](https://medium.com/diy-my-smart-home/project-smart-swimmingpool-4c40eb6741f6)
+, _Dezember 2018_
+
+  Englischer Blogpost über Version 1 des Smart Swimming Pool.
+
+  📄 [Hier auf der Seite lesen]({{< relref "/blog/smart-swimming-pool-project" >}})

--- a/content/docs/publications.de.md
+++ b/content/docs/publications.de.md
@@ -22,4 +22,4 @@ Auch verfügbar als [Blog-Beiträge](/blog/) auf dieser Seite.
 
   Englischer Blogpost über Version 1 des Smart Swimming Pool.
 
-  📄 [Hier auf der Seite lesen]({{< relref "/blog/smart-swimming-pool-project" >}})
+  📄 [Hier auf der Seite lesen]({{< relref "/blog/smart-swimming-pool-project" lang="en" >}})

--- a/content/docs/publications.de.md
+++ b/content/docs/publications.de.md
@@ -17,9 +17,8 @@ Auch verfügbar als [Blog-Beiträge](/blog/) auf dieser Seite.
   - [Swimmingpool und OpenHAB (3/4)]({{< relref "/blog/swimmingpool-openhab-3-4" >}})
   - [Der smarte Pool (4/4)]({{< relref "/blog/der-smarte-pool-4-4" >}})
 
-- [Project Smart Swimming Pool](https://medium.com/diy-my-smart-home/project-smart-swimmingpool-4c40eb6741f6)
-, _Dezember 2018_
+- [Project Smart Swimming Pool](https://medium.com/diy-my-smart-home/project-smart-swimmingpool-4c40eb6741f6), _Dezember 2018_
 
   Englischer Blogpost über Version 1 des Smart Swimming Pool.
 
-  📄 [Hier auf der Seite lesen]({{< relref "/blog/smart-swimming-pool-project" lang="en" >}})
+  📄 [Hier auf der Seite lesen]({{< relref path="/blog/smart-swimming-pool-project" lang="en" >}})

--- a/content/docs/publications.de.md
+++ b/content/docs/publications.de.md
@@ -4,7 +4,7 @@ weight: 80
 tags: ["docs", "publication"]
 ---
 
-Auch verfügbar als [Blog-Beiträge](/blog/) auf dieser Seite.
+Auch verfügbar als [Blog-Beiträge]({{< relref path="/blog" lang="de" >}}) auf dieser Seite.
 
 - [Projekt Smart Swimmingpool](https://www.az-delivery.de/blogs/azdelivery-blog-fur-arduino-und-raspberry-pi/projekt-smart-swimmingpool-einleitung), _Oktober 2018_
 

--- a/content/docs/publications.md
+++ b/content/docs/publications.md
@@ -1,10 +1,23 @@
 ---
 title: Publications
-weight: 20
+weight: 80
 tags: ["docs", "publication"]
 ---
+
+Also available as [blog posts](/blog/) on this site.
 
 - [Project Smart Swimming Pool](https://medium.com/diy-my-smart-home/project-smart-swimmingpool-4c40eb6741f6)
 , _December 2018_
 
   Blogpost of version 1 of Smart Swimming Pool
+
+  📄 [Read on this site]({{< relref "/blog/smart-swimming-pool-project" >}})
+
+- [Smart Swimming Pool: Introduction](/blog/projekt-smart-swimmingpool-einleitung/), _October 2018_
+
+  Four-part German blog series on AZ-Delivery Blog about version 1 of the Smart Pool Controller.
+
+  - [Smarte Steuerung für den Swimmingpool (1/4)]({{< relref "/blog/smarte-steuerung-1-4" >}})
+  - [Der Pool-Controller (2/4)]({{< relref "/blog/pool-controller-2-4" >}})
+  - [Swimmingpool und OpenHAB (3/4)]({{< relref "/blog/swimmingpool-openhab-3-4" >}})
+  - [Der smarte Pool (4/4)]({{< relref "/blog/der-smarte-pool-4-4" >}})

--- a/content/docs/publications.md
+++ b/content/docs/publications.md
@@ -13,11 +13,11 @@ Also available as [blog posts](/blog/) on this site.
 
   📄 [Read on this site]({{< relref "/blog/smart-swimming-pool-project" >}})
 
-- [Smart Swimming Pool: Introduction](/blog/projekt-smart-swimmingpool-einleitung/), _October 2018_
+- [Smart Swimming Pool: Introduction]({{< relref "/blog/projekt-smart-swimmingpool-einleitung" lang="de" >}}), _October 2018_
 
   Four-part German blog series on AZ-Delivery Blog about version 1 of the Smart Pool Controller.
 
-  - [Smarte Steuerung für den Swimmingpool (1/4)]({{< relref "/blog/smarte-steuerung-1-4" >}})
-  - [Der Pool-Controller (2/4)]({{< relref "/blog/pool-controller-2-4" >}})
-  - [Swimmingpool und OpenHAB (3/4)]({{< relref "/blog/swimmingpool-openhab-3-4" >}})
-  - [Der smarte Pool (4/4)]({{< relref "/blog/der-smarte-pool-4-4" >}})
+  - [Smarte Steuerung für den Swimmingpool (1/4)]({{< relref "/blog/smarte-steuerung-1-4" lang="de" >}})
+  - [Der Pool-Controller (2/4)]({{< relref "/blog/pool-controller-2-4" lang="de" >}})
+  - [Swimmingpool und OpenHAB (3/4)]({{< relref "/blog/swimmingpool-openhab-3-4" lang="de" >}})
+  - [Der smarte Pool (4/4)]({{< relref "/blog/der-smarte-pool-4-4" lang="de" >}})

--- a/content/docs/publications.md
+++ b/content/docs/publications.md
@@ -6,18 +6,17 @@ tags: ["docs", "publication"]
 
 Also available as [blog posts](/blog/) on this site.
 
-- [Project Smart Swimming Pool](https://medium.com/diy-my-smart-home/project-smart-swimmingpool-4c40eb6741f6)
-, _December 2018_
+- [Project Smart Swimming Pool](https://medium.com/diy-my-smart-home/project-smart-swimmingpool-4c40eb6741f6), _December 2018_
 
   Blogpost of version 1 of Smart Swimming Pool
 
   📄 [Read on this site]({{< relref "/blog/smart-swimming-pool-project" >}})
 
-- [Smart Swimming Pool: Introduction]({{< relref "/blog/projekt-smart-swimmingpool-einleitung" lang="de" >}}), _October 2018_
+- [Smart Swimming Pool: Introduction]({{< relref path="/blog/projekt-smart-swimmingpool-einleitung" lang="de" >}}), _October 2018_
 
   Four-part German blog series on AZ-Delivery Blog about version 1 of the Smart Pool Controller.
 
-  - [Smarte Steuerung für den Swimmingpool (1/4)]({{< relref "/blog/smarte-steuerung-1-4" lang="de" >}})
-  - [Der Pool-Controller (2/4)]({{< relref "/blog/pool-controller-2-4" lang="de" >}})
-  - [Swimmingpool und OpenHAB (3/4)]({{< relref "/blog/swimmingpool-openhab-3-4" lang="de" >}})
-  - [Der smarte Pool (4/4)]({{< relref "/blog/der-smarte-pool-4-4" lang="de" >}})
+  - [Smarte Steuerung für den Swimmingpool (1/4)]({{< relref path="/blog/smarte-steuerung-1-4" lang="de" >}})
+  - [Der Pool-Controller (2/4)]({{< relref path="/blog/pool-controller-2-4" lang="de" >}})
+  - [Swimmingpool und OpenHAB (3/4)]({{< relref path="/blog/swimmingpool-openhab-3-4" lang="de" >}})
+  - [Der smarte Pool (4/4)]({{< relref path="/blog/der-smarte-pool-4-4" lang="de" >}})

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -54,16 +54,20 @@ menu:
       name: Code of Conduct
       pageRef: /code-of-conduct
       weight: 2
+    - identifier: blog
+      name: Blog
+      pageRef: /blog
+      weight: 3
     - identifier: publications
       name: Publications
       pageRef: /docs/publications
-      weight: 3
+      weight: 5
     - name: Search
-      weight: 4
+      weight: 6
       params:
         type: search
     - name: GitHub
-      weight: 5
+      weight: 7
       url: "https://github.com/smart-swimmingpool"
       params:
         icon: github
@@ -105,12 +109,12 @@ params:
 
   blog:
     list:
-      displayTags: false
+      displayTags: true
       sortBy: date
       sortOrder: desc
       pagerSize: 20
     article:
-      displayPagination: false
+      displayPagination: true
 
   toc:
     displayTags: false


### PR DESCRIPTION
## Summary

Adds the full content of the Smart Swimming Pool blog posts to the website, sourced from the original Medium article and the AZ-Delivery German blog series.

## Changes

**New blog section on website:**
- `content/blog/_index.md` and `_index.de.md` — Blog section landing pages

**English post:**
- `content/blog/smart-swimming-pool-project.md` — Full English article originally published on Medium (Dec 2018)

**German series (5 posts):**
- `content/blog/projekt-smart-swimmingpool-einleitung.de.md` — Introduction
- `content/blog/smarte-steuerung-1-4.de.md` — Smarte Steuerung (1/4)
- `content/blog/pool-controller-2-4.de.md` — Der Pool-Controller (2/4)
- `content/blog/swimmingpool-openhab-3-4.de.md` — Swimmingpool und OpenHAB (3/4)
- `content/blog/der-smarte-pool-4-4.de.md` — Der smarte Pool (4/4)

**Config and navigation:**
- Added "Blog" entry to main menu in `hugo.yaml`
- Enabled blog tag display and pagination
- Updated Publications page to link to local blog posts alongside external sources

## Notes
- German posts use `{{< relref >}}` links for series navigation between parts
- Tags: Development, Deutsch, ESP32, openHAB
- Hugo build is needed to render (requires Hugo extended v0.146.0+)