### PR TITLE
[codex] Add focused MegaLinter workflow

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,32 @@
+name: MegaLinter
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: megalinter-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run MegaLinter
+        uses: oxsecurity/megalinter@v9.6.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,48 @@
+# Markdown Lint Configuration for MegaLinter
+# https://github.com/DavidAnson/markdownlint
+
+---
+default: true
+
+MD004:
+  style: dash
+
+MD007:
+  indent: 2
+  start_indented: false
+
+MD013:
+  line_length: 150
+  code_blocks: false
+  tables: false
+  headings: false
+
+MD024:
+  siblings_only: true
+
+MD025:
+  front_matter_title: ""
+
+MD031: false
+MD032: false
+MD040: false
+MD041: false
+
+MD033:
+  allowed_elements:
+    - a
+    - br
+    - details
+    - img
+    - kbd
+    - script
+    - span
+    - sub
+    - sup
+    - summary
+
+MD046:
+  style: fenced
+
+MD060:
+  style: around

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,0 +1,16 @@
+---
+APPLY_FIXES: none
+PRINT_ALPACA: false
+SHOW_ELAPSED_TIME: true
+
+# Start with low-noise linters that match this Hugo website repository.
+ENABLE_LINTERS:
+  - ACTION_ACTIONLINT
+  - EDITORCONFIG_EDITORCONFIG_CHECKER
+  - MARKDOWN_MARKDOWNLINT
+  - YAML_YAMLLINT
+
+FILTER_REGEX_EXCLUDE: '(^public/|^resources/|^temp/|^themes/|^node_modules/)'
+
+MARKDOWN_MARKDOWNLINT_CONFIG_FILE: .markdownlint.yml
+YAML_YAMLLINT_CONFIG_FILE: .yamllint.yml

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,25 @@
+# YAML Lint Configuration for MegaLinter
+# https://yamllint.readthedocs.io/
+
+---
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+
+  document-start: disable
+
+  indentation:
+    spaces: 2
+    indent-sequences: true
+
+  line-length:
+    max: 120
+    level: warning
+
+  new-line-at-end-of-file: enable
+
+  truthy:
+    allowed-values: ["true", "false", "yes", "no"]
+    check-keys: false


### PR DESCRIPTION
## Summary

Adds MegaLinter as a separate, focused CI workflow instead of introducing the broad default linter set from the documentation cleanup PR.

## What changed

- Adds `.github/workflows/linter.yml` using `oxsecurity/megalinter@v9.6.0`.
- Adds `.mega-linter.yml` with a curated low-noise linter set for this Hugo website repository.
- Adds Markdown and YAML lint configuration files.
- Runs changed-file validation on pull requests and full validation on pushes to `main`.

## Why

The default MegaLinter setup in the related PR uses an old version and enables many repo-wide checks at once. That creates noisy failures from spell checking, security scanners, HTML, Python, and link checks that are not all part of the documentation change. This PR introduces MegaLinter separately and starts with maintainable checks for Actions, EditorConfig, Markdown, and YAML.

## Validation

- Parsed all new YAML files locally with Python/PyYAML.
- Ran `git diff --check`.

The actual MegaLinter result should be verified by this draft PR's GitHub Actions run.