### PR TITLE
chore(license): update MIT license copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2020 Smart Swimmingpool, Stephan Strittmatter
+Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Update LICENSE: copyright year 2019-2020 → 2018-2026, unify copyright holder name.