### PR TITLE
docs: add Hugo multilingual naming convention guidelines to OpenCode skill

### DIFF
--- a/.opencode/skills/SKILL.md
+++ b/.opencode/skills/SKILL.md
@@ -173,12 +173,19 @@ language switcher, and URL structure.
 
 - **Required:** `title` in the respective language, `date`
 - **Optional:** `draft`, `tags`, `weight`, `description`
-- **Cross-linking:** Use Hugo's `relref` shortcode with the `lang` parameter for cross-language links:
+- **Cross-linking:** Use Hugo's `relref` shortcode with the `lang` parameter for cross-language links.
+  For pages where English and German share the same logical path (section indexes, same-slug pages):
   ```markdown
   {{< relref path="docs/getting-started" lang="en" >}}
   {{< relref path="docs/getting-started" lang="de" >}}
   ```
-- Do **not** use `content/de/` paths in `relref` — always reference the canonical English path with `lang="de"`
+- Do **not** use `content/de/` paths in `relref` — always reference the canonical path with `lang="de"`
+- ⚠️ **For independent filenames (blog posts):** The `path` must point to the actual file path
+  in the target language, because the English and German slugs differ:
+  ```markdown
+  {{< relref path="/blog/projekt-smart-swimmingpool-einleitung" lang="de" >}}
+  {{< relref path="/blog/smart-swimming-pool-project" lang="en" >}}
+  ```
 - **Translation linking for independent filenames:** When English and German files use different
   base names (e.g. blog posts with language-specific slugs), Hugo does **not** auto-link them
   as translations. Add a shared `translationKey` frontmatter field in **both** files:

--- a/.opencode/skills/SKILL.md
+++ b/.opencode/skills/SKILL.md
@@ -155,11 +155,19 @@ language switcher, and URL structure.
 - English: `content/blog/<english-slug>.md`
 - German: `content/blog/<german-slug>.de.md`
 - Filenames are **independent per language** (not just a suffix swap) — each uses a slug in its own language
+- ⚠️ Because the base names differ, Hugo will **not** auto-link them as translations. Add a
+  shared `translationKey` in both files' frontmatter (see Frontmatter Rules below)
 - Example: `content/blog/smart-swimming-pool-project.md` and `content/blog/projekt-smart-swimmingpool-einleitung.de.md`
+  — these are paired via `translationKey: "smart-pool-project"`, not by filename
 
 **Generated docs (via `grabrepos.py`):**
-- The script only copies English docs from module repos. German translations for `_index.md` are maintained manually in this repo
-- Generated directories (`.gitignore`d) follow the same naming rules if manual German pages are added alongside them
+- The script copies all `_index.md` and `_index.de.md` files from source module repos — it already
+  handles German landing pages if they exist in the source
+- Add German `_index.de.md` files directly in the **source module repo** (`smart-swimmingpool/pool-controller`,
+  `smart-swimmingpool/openhab-config`, etc.), not in this repo
+- The generated directories (`content/docs/pool-controller/`, etc.) are **gitignored** — manual files
+  placed there will never be committed. If an override in this repo is absolutely required, modify
+  `.gitignore` to allow specific `.de.md` files first
 
 #### Frontmatter Rules
 
@@ -171,6 +179,18 @@ language switcher, and URL structure.
   {{< relref path="docs/getting-started" lang="de" >}}
   ```
 - Do **not** use `content/de/` paths in `relref` — always reference the canonical English path with `lang="de"`
+- **Translation linking for independent filenames:** When English and German files use different
+  base names (e.g. blog posts with language-specific slugs), Hugo does **not** auto-link them
+  as translations. Add a shared `translationKey` frontmatter field in **both** files:
+  ```yaml
+  # English: content/blog/smart-swimming-pool-project.md
+  title: "Smart Swimming Pool Project"
+  translationKey: "smart-pool-project"
+  ---
+  # German: content/blog/projekt-smart-swimmingpool-einleitung.de.md
+  title: "Projekt Smart Swimmingpool – Einleitung"
+  translationKey: "smart-pool-project"
+  ```
 
 #### Validation Checklist
 
@@ -181,6 +201,7 @@ When adding or reviewing multilingual content:
 - [ ] Frontmatter `title` is translated, not copied from English
 - [ ] Cross-language `relref` links use the `lang` parameter
 - [ ] No duplicate content at `content/de/...` paths
+- [ ] Independent filename pairs (blog posts) share a `translationKey` in frontmatter
 
 ### Hugo Config
 

--- a/.opencode/skills/SKILL.md
+++ b/.opencode/skills/SKILL.md
@@ -114,10 +114,66 @@ content/docs/pool-monitor/
 
 ### Translation Pattern
 
-- English: `page.md` / `page.de.md`
-- German pages mirror English structure
-- `_index.md` → section landing, `_index.de.md` → German landing
-- Frontmatter: YAML with `title`, `date`, `draft`, `tags`, etc.
+This project uses Hugo's **filename-suffix** translation system (`hugo.yaml` has `languages: [en, de]` with no custom `contentDir`).
+
+**Core rule:** German translations always use the `.de.md` suffix in the **same directory** as the English original. Never place German files in a `content/de/` subdirectory — Hugo would treat them as default-language content at a `/de/` path, breaking the sidebar, language switcher, and URL structure.
+
+#### File Naming Conventions
+
+| English | German | Description |
+|---------|--------|-------------|
+| `_index.md` | `_index.de.md` | Section landing page (directory index) |
+| `page.md` | `page.de.md` | Regular content page |
+| `code-of-conduct.md` | `code-of-conduct.de.md` | Root-level standalone page |
+| `smart-swimming-pool-project.md` | `projekt-smart-swimmingpool-einleitung.de.md` | Blog post (independent filenames per language) |
+
+#### Rules per Content Type
+
+**Section landing pages (`_index.md`):**
+- English: `content/docs/<section>/_index.md`
+- German: `content/docs/<section>/_index.de.md` (same directory)
+- Both share frontmatter fields like `title`, `weight`, `tags` — each in its own language
+- Example: `content/docs/architecture/_index.md` + `content/docs/architecture/_index.de.md`
+
+**Regular doc pages:**
+- Place the German `.de.md` file right next to the English `.md` file
+- Never use `content/de/docs/...` paths
+- This applies across all doc sections: `getting-started/`, `faq/`, `quickstart/`, `migration/`, `troubleshooting/`, etc.
+
+**Root-level pages (`content/`):**
+- Same pattern: `content/privacy.md` + `content/privacy.de.md`
+- Examples: `code-of-conduct`, `license`, `privacy`
+
+**Blog posts:**
+- English: `content/blog/<english-slug>.md`
+- German: `content/blog/<german-slug>.de.md`
+- Filenames are **independent per language** (not just a suffix swap) — each uses a slug in its own language
+- Example: `content/blog/smart-swimming-pool-project.md` and `content/blog/projekt-smart-swimmingpool-einleitung.de.md`
+
+**Generated docs (via `grabrepos.py`):**
+- The script only copies English docs from module repos. German translations for `_index.md` are maintained manually in this repo
+- Generated directories (`.gitignore`d) follow the same naming rules if manual German pages are added alongside them
+
+#### Frontmatter Rules
+
+- **Required:** `title` in the respective language, `date`
+- **Optional:** `draft`, `tags`, `weight`, `description`
+- **Cross-linking:** Use Hugo's `relref` shortcode with the `lang` parameter for cross-language links:
+  ```markdown
+  {{< relref path="docs/getting-started" lang="en" >}}
+  {{< relref path="docs/getting-started" lang="de" >}}
+  ```
+- Do **not** use `content/de/` paths in `relref` — always reference the canonical English path with `lang="de"`
+
+#### Validation Checklist
+
+When adding or reviewing multilingual content:
+
+- [ ] German file has `.de.md` suffix (not in `content/de/` subdirectory)
+- [ ] Both `_index.md` and `_index.de.md` exist in the same directory
+- [ ] Frontmatter `title` is translated, not copied from English
+- [ ] Cross-language `relref` links use the `lang` parameter
+- [ ] No duplicate content at `content/de/...` paths
 
 ### Hugo Config
 

--- a/.opencode/skills/SKILL.md
+++ b/.opencode/skills/SKILL.md
@@ -2,7 +2,9 @@
 
 ## Project Overview
 
-Static documentation site for [Smart Swimming Pool](https://smart-swimmingpool.com), built with **Hugo** + **Hextra theme**. Hosted on GitHub Pages. Supports **EN + DE** translations.
+Static documentation site for [Smart Swimming Pool](https://smart-swimmingpool.com),
+built with **Hugo** + **Hextra theme**. Hosted on GitHub Pages.
+Supports **EN + DE** translations.
 
 ## Architecture
 
@@ -19,16 +21,16 @@ Static documentation site for [Smart Swimming Pool](https://smart-swimmingpool.c
 │  │  GitHub Actions (CI) ─► Hugo ─► GitHub Pages│   │
 │  └─────────────────────────────────────────────┘   │
 └──────────────────────────────────────────────────┘
-         ▲                    ▲
-         │ module docs        │ repository_dispatch
-         │ (cloned/fetched)   │ (doc_update)
-┌────────┴────────┐   ┌───────┴────────┐
-│ Module Repos    │   │ Daily Cron     │
-│ pool-controller │   │ 6:00 UTC       │
-│ openhab-config  │   └────────────────┘
-│ grafana-dash.   │
-│ monitor         │
-└─────────────────┘
+        ▲                    ▲
+        │ module docs        │ repository_dispatch
+        │ (cloned/fetched)   │ (doc_update)
+┌───────┴────────┐   ┌──────┴─────────┐
+│ Module Repos   │   │ Daily Cron     │
+│ pool-controller│   │ 6:00 UTC       │
+│ openhab-config │   └────────────────┘
+│ grafana-dash.  │
+│ monitor        │
+└────────────────┘
 ```
 
 ## Module Documentation Workflow
@@ -48,10 +50,10 @@ Four external module repos provide documentation that is merged into the website
 2. **Clones/fetches each repo** into `temp/<name>/`
 3. **Scans for matching files** (default: `docs/**/*.md`)
 4. **For each file**:
-   - Extracts frontmatter (YAML) with `extract_frontmatter()`
-   - Checks for `##` headings via `split_by_headings()`
-   - **`_index.md` files** are always written (even without `##` headings)
-   - **Other files** are skipped if they have no `##` sections
+    - Extracts frontmatter (YAML) with `extract_frontmatter()`
+    - Checks for `##` headings via `split_by_headings()`
+    - **`_index.md` files** are always written (even without `##` headings)
+    - **Other files** are skipped if they have no `##` sections
 5. **Writes output** to `content/docs/<reponame>/` with combined frontmatter (source info + preserved metadata)
 
 ### Key Files
@@ -82,7 +84,9 @@ hugo server -D
 ### Known `grabrepos.py` Edge Cases
 
 - **No `##` headings in `_index.md`**: Safe — always written regardless
-- **Malformed YAML frontmatter** (e.g. `summary:Überwache` — missing space after colon): `extract_frontmatter` returns empty metadata but still strips frontmatter from body to avoid duplication
+- **Malformed YAML frontmatter** (e.g. `summary:Überwache` — missing space after colon):
+  `extract_frontmatter` returns empty metadata but still strips frontmatter from body
+  to avoid duplication
 - **Internal documents**: Skipped if frontmatter has `noindex: true` + `private: true`
 
 ### Build Triggers
@@ -116,7 +120,10 @@ content/docs/pool-monitor/
 
 This project uses Hugo's **filename-suffix** translation system (`hugo.yaml` has `languages: [en, de]` with no custom `contentDir`).
 
-**Core rule:** German translations always use the `.de.md` suffix in the **same directory** as the English original. Never place German files in a `content/de/` subdirectory — Hugo would treat them as default-language content at a `/de/` path, breaking the sidebar, language switcher, and URL structure.
+**Core rule:** German translations always use the `.de.md` suffix in the **same directory**
+as the English original. Never place German files in a `content/de/` subdirectory — Hugo
+would treat them as default-language content at a `/de/` path, breaking the sidebar,
+language switcher, and URL structure.
 
 #### File Naming Conventions
 


### PR DESCRIPTION
## Summary

Adds comprehensive Hugo multilingual file naming convention guidelines to the project's OpenCode skill (), based on issues identified in Codex review of PR #11.

### Changes

- **** — Expanded Translation Pattern section with:
  - **Core rule:** German translations use `.de.md` suffix in the same directory — never `content/de/` subdirectories
  - **File naming conventions table** for all content types (`_index.md`, regular pages, root-level pages, blog posts)
  - **Rules per content type** with concrete examples from the codebase
  - **Frontmatter and cross-linking guidelines** including `relref` with `lang` parameter
  - **Validation checklist** with 5 items for adding/reviewing multilingual content

### Why

PR #11's Codex review flagged that the German Start Here page was placed under `content/de/` instead of using the `.de.md` suffix convention. While the content was fixed before merge, the convention was undocumented. This PR encodes it as a repeatable reference for AI agents working on this repo.

### Validation Checklist Applied

- [x] All existing content uses correct `.de.md` suffix convention
- [x] No `content/de/` paths remain in the repository
- [x] `_index.md` / `_index.de.md` pairs exist in all section directories